### PR TITLE
TermStation demo: allow deny without token

### DIFF
--- a/demos/external-auth-termstation-adapter/src/server.ts
+++ b/demos/external-auth-termstation-adapter/src/server.ts
@@ -201,7 +201,7 @@ async function createTermStationNotification(
       id: inputId,
       label: "Token",
       type: tokenMacro.secret ? "secret" : "secret",
-      required: tokenMacro.required !== false,
+      required: false,
     });
   }
 


### PR DESCRIPTION
Update TermStation demo so the deny action does not require a GitHub token input.

Summary of changes:
- Adjust TermStation notification payload in the external-auth TermStation adapter demo so the `github_token` input is no longer globally required.
- Keep the "Approve" (allow) action requiring the `github_token` via `requires_inputs`.
- Allow the "Deny" action to be chosen without providing a token, matching TermStation per-action input semantics.

Testing performed:
- demos/external-auth-termstation-adapter: npm install && npm run build
- Rust tests were not re-run, since no Rust code was changed.

Session: 0cd20031-93ab-43a4-988d-9cd64ceae401 (codex)

Linked issue: #26 
