### PR TITLE
Add multi-pattern policy rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Added
+- Add `patterns = [...]` policy rule support for expanding several URL patterns with shared rule attributes into singular effective rules.
 
 ## [0.0.12] - 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- Add `patterns = [...]` policy rule support for expanding several URL patterns with shared rule attributes into singular effective rules.
+- Add `patterns = [...]` policy rule support for expanding several URL patterns with shared rule attributes into singular effective rules ([#48](https://github.com/kcosr/acl-proxy/pull/48)).
 
 ## [0.0.12] - 2026-03-19
 

--- a/README.md
+++ b/README.md
@@ -343,6 +343,31 @@ description = "Allow trusted workload identities"
 - Empty configured values are rejected during config validation.
 - When both `headers_absent` and `headers_match` are configured, both predicates must pass.
 
+### Multiple URL Patterns
+
+Use `patterns = [...]` when several URL patterns should share identical rule attributes:
+
+```toml
+[[policy.rules]]
+action = "allow"
+patterns = [
+  "https://developers.openai.com/**",
+  "https://github.com/openai/**",
+  "https://raw.githubusercontent.com/openai/**",
+  "https://api.github.com/repos/openai/**",
+]
+methods = ["GET"]
+description = "OpenAI docs and repositories"
+```
+
+- Use `pattern = "..."` for one URL pattern and `patterns = ["...", "..."]` for several.
+- `pattern` and `patterns` are mutually exclusive.
+- `patterns` must include at least one non-empty pattern; entries are trimmed before expansion.
+- A multi-pattern rule expands into one effective rule per pattern, preserving configured pattern order and first-match-wins behavior.
+- `policy dump` shows the expanded effective rules with singular `pattern` values.
+- Policy decision logs report the specific matched effective `rule_pattern`, not the original `patterns` array.
+- `rule_id` is rejected on multi-pattern rules because copied IDs would not be unique.
+
 ### Macros and Rulesets
 
 Macros are named placeholders expanded before patterns are compiled:
@@ -357,6 +382,8 @@ pattern = "https://git.internal/{repo}.git/**"
 description = "Git HTTP(S) for {repo}"
 methods = ["GET", "POST"]
 ```
+
+Ruleset templates can also use `patterns = [...]`; include expansion emits one concrete rule for each template pattern.
 
 Include rules expand a ruleset into concrete rules:
 
@@ -445,6 +472,7 @@ acl-proxy policy dump --format json
 ```
 
 `policy dump` defaults to table output on a TTY and JSON otherwise. It includes `headers_match` values — treat output as sensitive when those values represent credentials.
+When a rule uses `patterns`, the dump shows one effective row/object per expanded pattern with a singular `pattern` field.
 
 ## Configuration Reference
 
@@ -654,6 +682,7 @@ See [Policy Engine](#policy-engine) for full details on rules, macros, rulesets,
 [[policy.rules]]
 action = "allow"                    # required: "allow" | "deny"
 pattern = "https://example.com/**"  # optional: URL pattern
+# patterns = ["https://a/**"]       # optional alternative: multiple URL patterns
 description = "Example rule"        # optional
 methods = ["GET", "POST"]           # optional: HTTP methods
 subnets = ["10.0.0.0/8"]           # optional: client IP CIDRs
@@ -664,7 +693,7 @@ rule_id = "stable-id"             # optional: stable ID for webhooks
 external_auth_profile = "name"     # optional: approval gate (allow rules only)
 ```
 
-At least one of `pattern`, `methods`, `subnets`, `headers_absent`, or `headers_match` must be present.
+At least one of `pattern`, `patterns`, `methods`, `subnets`, `headers_absent`, or `headers_match` must be present.
 
 #### Include Rule Fields
 
@@ -737,7 +766,9 @@ The repository includes [`acl-proxy.sample.toml`](acl-proxy.sample.toml) as a co
 The config loader performs validation beyond basic TOML parsing:
 
 - `schema_version` must equal `"1"`.
-- Direct rules must have at least one of `pattern`, `methods`, `subnets`, `headers_absent`, or `headers_match`.
+- Direct rules must have at least one of `pattern`, `patterns`, `methods`, `subnets`, `headers_absent`, or `headers_match`.
+- Direct rules and ruleset templates must not define both `pattern` and `patterns`.
+- `patterns` must include at least one non-empty pattern.
 - Include rules must reference an existing ruleset.
 - Macro placeholders (`{name}`) must resolve from `policy.macros` or `with` overrides.
 - `ca_key_path` and `ca_cert_path` must be both set or both omitted.

--- a/README.md
+++ b/README.md
@@ -769,6 +769,7 @@ The config loader performs validation beyond basic TOML parsing:
 - Direct rules must have at least one of `pattern`, `patterns`, `methods`, `subnets`, `headers_absent`, or `headers_match`.
 - Direct rules and ruleset templates must not define both `pattern` and `patterns`.
 - `patterns` must include at least one non-empty pattern.
+- Duplicate `patterns` entries are rejected after trimming.
 - Include rules must reference an existing ruleset.
 - Macro placeholders (`{name}`) must resolve from `policy.macros` or `with` overrides.
 - `ca_key_path` and `ca_cert_path` must be both set or both omitted.

--- a/acl-proxy.sample.toml
+++ b/acl-proxy.sample.toml
@@ -265,6 +265,18 @@ description = "Allow trusted workload identities"
 methods = ["GET", "POST"]
 
 [[policy.rules]]
+# Example: group several URL patterns that share the same rule attributes.
+action = "allow"
+patterns = [
+  "https://developers.openai.com/**",
+  "https://github.com/openai/**",
+  "https://raw.githubusercontent.com/openai/**",
+  "https://api.github.com/repos/openai/**",
+]
+description = "OpenAI docs and repositories"
+methods = ["GET"]
+
+[[policy.rules]]
 # Allow Git traffic (HTTP(S) and API) for repositories listed in
 # [policy.macros].repo from the 10.0.0.0/8 network, including URL
 # encoded variants of the {repo} placeholder.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -945,7 +945,7 @@ impl Config {
 
             if !has_match_criteria {
                 return Err(ConfigError::Invalid(format!(
-                    "policy.rules[{idx}] must specify at least one of pattern, subnets, methods, headers_absent, headers_match, or include"
+                    "policy.rules[{idx}] must specify at least one of pattern, patterns, subnets, methods, headers_absent, headers_match, or include"
                 )));
             }
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -493,7 +493,12 @@ pub enum PolicyDefaultAction {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PolicyRuleTemplateConfig {
     pub action: PolicyDefaultAction,
-    pub pattern: String,
+
+    #[serde(default)]
+    pub pattern: Option<String>,
+
+    #[serde(default)]
+    pub patterns: Option<Vec<String>>,
 
     #[serde(default)]
     pub description: Option<String>,
@@ -558,6 +563,9 @@ pub struct PolicyRuleDirectConfig {
 
     #[serde(default)]
     pub pattern: Option<String>,
+
+    #[serde(default)]
+    pub patterns: Option<Vec<String>>,
 
     #[serde(default)]
     pub description: Option<String>,
@@ -926,6 +934,7 @@ impl Config {
             let has_match_criteria = match rule {
                 PolicyRuleConfig::Direct(d) => {
                     d.pattern.is_some()
+                        || d.patterns.is_some()
                         || !d.subnets.is_empty()
                         || d.methods.is_some()
                         || d.headers_absent.is_some()

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -13,7 +13,8 @@ use crate::config::{
     EgressRequestHeaderActionConfig, ExternalAuthProfileConfigMap, HeaderActionConfig,
     HeaderActionKind, HeaderDirection, HeaderMatchValueConfig, HeaderWhen, MacroMap,
     MacroOverrideMap, MacroValues, PolicyConfig, PolicyDefaultAction, PolicyRuleConfig,
-    PolicyRuleDirectConfig, PolicyRuleIncludeConfig, RulesetMap, UrlEncVariants,
+    PolicyRuleDirectConfig, PolicyRuleIncludeConfig, PolicyRuleTemplateConfig, RulesetMap,
+    UrlEncVariants,
 };
 
 #[derive(Debug, Error)]
@@ -109,6 +110,11 @@ struct ExpandedRule {
     request_timeout_ms: Option<u64>,
     header_actions: Vec<HeaderActionConfig>,
     external_auth_profile: Option<String>,
+}
+
+struct TemplatePatterns<'a> {
+    template: &'a PolicyRuleTemplateConfig,
+    patterns: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -401,12 +407,14 @@ fn expand_direct_rule(
     index: usize,
     out: &mut Vec<ExpandedRule>,
 ) -> Result<(), PolicyError> {
-    let pattern = rule
-        .pattern
-        .as_ref()
-        .map(|p| p.trim())
-        .filter(|p| !p.is_empty())
-        .map(|p| p.to_string());
+    let patterns = normalize_patterns(
+        rule.pattern.as_ref(),
+        rule.patterns.as_deref(),
+        index,
+        "policy rule",
+        false,
+    )?;
+    reject_multi_pattern_rule_id(patterns.as_deref(), rule.rule_id.as_ref(), index)?;
 
     let methods = rule
         .methods
@@ -430,7 +438,7 @@ fn expand_direct_rule(
         }
     }
 
-    let has_pattern = pattern.is_some();
+    let has_pattern = patterns.is_some();
     let has_subnets = !rule.subnets.is_empty();
     let has_methods = !methods.is_empty();
     let headers_absent = validate_headers_absent(rule.headers_absent.as_deref(), index)?;
@@ -464,9 +472,11 @@ fn expand_direct_rule(
         });
     }
 
-    let pattern_str = pattern.unwrap();
+    let patterns = patterns.unwrap();
     let mut placeholders = BTreeSet::new();
-    collect_placeholders(&pattern_str, &mut placeholders);
+    for pattern in &patterns {
+        collect_placeholders(pattern, &mut placeholders);
+    }
     if let Some(desc) = &rule.description {
         collect_placeholders(desc, &mut placeholders);
     }
@@ -476,26 +486,28 @@ fn expand_direct_rule(
     }
 
     if placeholders.is_empty() {
-        out.push(ExpandedRule {
-            action: rule.action,
-            pattern: Some(pattern_str),
-            description: rule.description.clone(),
-            rule_id: rule.rule_id.clone(),
-            subnets: rule.subnets.clone(),
-            methods,
-            headers_absent,
-            headers_match,
-            request_timeout_ms: rule.request_timeout_ms,
-            header_actions: rule.header_actions.clone(),
-            external_auth_profile: rule.external_auth_profile.clone(),
-        });
+        for pattern in patterns {
+            out.push(ExpandedRule {
+                action: rule.action,
+                pattern: Some(pattern),
+                description: rule.description.clone(),
+                rule_id: rule.rule_id.clone(),
+                subnets: rule.subnets.clone(),
+                methods: methods.clone(),
+                headers_absent: headers_absent.clone(),
+                headers_match: headers_match.clone(),
+                request_timeout_ms: rule.request_timeout_ms,
+                header_actions: rule.header_actions.clone(),
+                external_auth_profile: rule.external_auth_profile.clone(),
+            });
+        }
         return Ok(());
     }
 
     let resolved = resolve_placeholders(rule.with.as_ref(), macros, &placeholders, |_| {
         format!(
             " (required by direct rule pattern {pattern})",
-            pattern = pattern_str
+            pattern = patterns.join(", ")
         )
     })?;
 
@@ -506,7 +518,6 @@ fn expand_direct_rule(
     }
 
     for combo in combos {
-        let pattern_interp = interpolate_template(&pattern_str, &combo);
         let description_interp = rule
             .description
             .as_ref()
@@ -516,18 +527,90 @@ fn expand_direct_rule(
             .as_ref()
             .map(|id| interpolate_template(id, &combo));
 
-        out.push(ExpandedRule {
-            action: rule.action,
-            pattern: Some(pattern_interp),
-            description: description_interp,
-            rule_id: rule_id_interp,
-            subnets: rule.subnets.clone(),
-            methods: methods.clone(),
-            headers_absent: headers_absent.clone(),
-            headers_match: headers_match.clone(),
-            request_timeout_ms: rule.request_timeout_ms,
-            header_actions: rule.header_actions.clone(),
-            external_auth_profile: rule.external_auth_profile.clone(),
+        for pattern in &patterns {
+            let pattern_interp = interpolate_template(pattern, &combo);
+            out.push(ExpandedRule {
+                action: rule.action,
+                pattern: Some(pattern_interp),
+                description: description_interp.clone(),
+                rule_id: rule_id_interp.clone(),
+                subnets: rule.subnets.clone(),
+                methods: methods.clone(),
+                headers_absent: headers_absent.clone(),
+                headers_match: headers_match.clone(),
+                request_timeout_ms: rule.request_timeout_ms,
+                header_actions: rule.header_actions.clone(),
+                external_auth_profile: rule.external_auth_profile.clone(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn normalize_patterns(
+    pattern: Option<&String>,
+    patterns: Option<&[String]>,
+    index: usize,
+    context: &str,
+    require_pattern: bool,
+) -> Result<Option<Vec<String>>, PolicyError> {
+    if pattern.is_some() && patterns.is_some() {
+        return Err(PolicyError::RuleInvalid {
+            index,
+            reason: format!("{context} must not define both pattern and patterns"),
+        });
+    }
+
+    if let Some(patterns) = patterns {
+        if patterns.is_empty() {
+            return Err(PolicyError::RuleInvalid {
+                index,
+                reason: "patterns must include at least one pattern".to_string(),
+            });
+        }
+
+        let mut normalized = Vec::with_capacity(patterns.len());
+        for (entry_idx, pattern) in patterns.iter().enumerate() {
+            let trimmed = pattern.trim();
+            if trimmed.is_empty() {
+                return Err(PolicyError::RuleInvalid {
+                    index,
+                    reason: format!("patterns entry at index {entry_idx} must not be empty"),
+                });
+            }
+            normalized.push(trimmed.to_string());
+        }
+
+        return Ok(Some(normalized));
+    }
+
+    let pattern = pattern
+        .map(|p| p.trim())
+        .filter(|p| !p.is_empty())
+        .map(|p| p.to_string());
+
+    if pattern.is_none() && require_pattern {
+        return Err(PolicyError::RuleInvalid {
+            index,
+            reason: format!("{context} must define either pattern or patterns"),
+        });
+    }
+
+    Ok(pattern.map(|p| vec![p]))
+}
+
+fn reject_multi_pattern_rule_id(
+    patterns: Option<&[String]>,
+    rule_id: Option<&String>,
+    index: usize,
+) -> Result<(), PolicyError> {
+    if rule_id.is_some() && patterns.is_some_and(|patterns| patterns.len() > 1) {
+        return Err(PolicyError::RuleInvalid {
+            index,
+            reason:
+                "rule_id is not allowed on multi-pattern rules unless unique effective rule IDs are configured"
+                    .to_string(),
         });
     }
 
@@ -567,9 +650,26 @@ fn expand_include_rule(
         }
     }
 
-    let mut placeholders = BTreeSet::new();
+    let mut template_patterns = Vec::with_capacity(templates.len());
     for template in templates {
-        collect_placeholders(&template.pattern, &mut placeholders);
+        let patterns = normalize_patterns(
+            template.pattern.as_ref(),
+            template.patterns.as_deref(),
+            index,
+            "policy ruleset template",
+            true,
+        )?
+        .expect("ruleset template normalization requires patterns");
+        reject_multi_pattern_rule_id(Some(patterns.as_slice()), template.rule_id.as_ref(), index)?;
+        template_patterns.push(TemplatePatterns { template, patterns });
+    }
+
+    let mut placeholders = BTreeSet::new();
+    for template_patterns in &template_patterns {
+        for pattern in &template_patterns.patterns {
+            collect_placeholders(pattern, &mut placeholders);
+        }
+        let template = template_patterns.template;
         if let Some(desc) = &template.description {
             collect_placeholders(desc, &mut placeholders);
         }
@@ -579,7 +679,8 @@ fn expand_include_rule(
     }
 
     if placeholders.is_empty() {
-        for template in templates {
+        for template_patterns in &template_patterns {
+            let template = template_patterns.template;
             let headers_absent =
                 validate_headers_absent(template.headers_absent.as_deref(), index)?;
             let headers_match = validate_headers_match(template.headers_match.as_ref(), index)?;
@@ -591,23 +692,25 @@ fn expand_include_rule(
                 .unwrap_or_default();
             let request_timeout_ms = rule.request_timeout_ms.or(template.request_timeout_ms);
 
-            out.push(ExpandedRule {
-                action: template.action,
-                pattern: Some(template.pattern.clone()),
-                description: template.description.clone(),
-                rule_id: template.rule_id.clone(),
-                subnets: if !rule.subnets.is_empty() {
-                    rule.subnets.clone()
-                } else {
-                    template.subnets.clone()
-                },
-                methods,
-                headers_absent,
-                headers_match,
-                request_timeout_ms,
-                header_actions: template.header_actions.clone(),
-                external_auth_profile: template.external_auth_profile.clone(),
-            });
+            for pattern in &template_patterns.patterns {
+                out.push(ExpandedRule {
+                    action: template.action,
+                    pattern: Some(pattern.clone()),
+                    description: template.description.clone(),
+                    rule_id: template.rule_id.clone(),
+                    subnets: if !rule.subnets.is_empty() {
+                        rule.subnets.clone()
+                    } else {
+                        template.subnets.clone()
+                    },
+                    methods: methods.clone(),
+                    headers_absent: headers_absent.clone(),
+                    headers_match: headers_match.clone(),
+                    request_timeout_ms,
+                    header_actions: template.header_actions.clone(),
+                    external_auth_profile: template.external_auth_profile.clone(),
+                });
+            }
         }
         return Ok(());
     }
@@ -623,7 +726,8 @@ fn expand_include_rule(
     }
 
     for combo in combos {
-        for template in templates {
+        for template_patterns in &template_patterns {
+            let template = template_patterns.template;
             let headers_absent =
                 validate_headers_absent(template.headers_absent.as_deref(), index)?;
             let headers_match = validate_headers_match(template.headers_match.as_ref(), index)?;
@@ -635,7 +739,6 @@ fn expand_include_rule(
                 .unwrap_or_default();
             let request_timeout_ms = rule.request_timeout_ms.or(template.request_timeout_ms);
 
-            let pattern_interp = interpolate_template(&template.pattern, &combo);
             let description_interp = template
                 .description
                 .as_ref()
@@ -645,23 +748,26 @@ fn expand_include_rule(
                 .as_ref()
                 .map(|id| interpolate_template(id, &combo));
 
-            out.push(ExpandedRule {
-                action: template.action,
-                pattern: Some(pattern_interp),
-                description: description_interp,
-                rule_id: rule_id_interp,
-                subnets: if !rule.subnets.is_empty() {
-                    rule.subnets.clone()
-                } else {
-                    template.subnets.clone()
-                },
-                methods,
-                headers_absent,
-                headers_match,
-                request_timeout_ms,
-                header_actions: template.header_actions.clone(),
-                external_auth_profile: template.external_auth_profile.clone(),
-            });
+            for pattern in &template_patterns.patterns {
+                let pattern_interp = interpolate_template(pattern, &combo);
+                out.push(ExpandedRule {
+                    action: template.action,
+                    pattern: Some(pattern_interp),
+                    description: description_interp.clone(),
+                    rule_id: rule_id_interp.clone(),
+                    subnets: if !rule.subnets.is_empty() {
+                        rule.subnets.clone()
+                    } else {
+                        template.subnets.clone()
+                    },
+                    methods: methods.clone(),
+                    headers_absent: headers_absent.clone(),
+                    headers_match: headers_match.clone(),
+                    request_timeout_ms,
+                    header_actions: template.header_actions.clone(),
+                    external_auth_profile: template.external_auth_profile.clone(),
+                });
+            }
         }
     }
 
@@ -1424,6 +1530,7 @@ mod tests {
             rules: vec![PolicyRuleConfig::Direct(PolicyRuleDirectConfig {
                 action: PolicyDefaultAction::Allow,
                 pattern: None,
+                patterns: None,
                 description: None,
                 methods: None,
                 subnets: vec!["192.168.0.0/16".parse::<IpNet>().unwrap()],
@@ -1454,6 +1561,7 @@ mod tests {
             rules: vec![PolicyRuleConfig::Direct(PolicyRuleDirectConfig {
                 action: PolicyDefaultAction::Allow,
                 pattern: None,
+                patterns: None,
                 description: None,
                 methods: None,
                 subnets: vec!["2001:db8::/32".parse::<IpNet>().unwrap()],
@@ -1490,7 +1598,8 @@ mod tests {
             vec![
                 PolicyRuleTemplateConfig {
                     action: allow_action(),
-                    pattern: "https://gitlab.internal/api/v4/projects/{repo}?**".to_string(),
+                    pattern: Some("https://gitlab.internal/api/v4/projects/{repo}?**".to_string()),
+                    patterns: None,
                     description: None,
                     methods: None,
                     subnets: Vec::new(),
@@ -1503,7 +1612,8 @@ mod tests {
                 },
                 PolicyRuleTemplateConfig {
                     action: allow_action(),
-                    pattern: "https://gitlab.internal/{repo}.git/**".to_string(),
+                    pattern: Some("https://gitlab.internal/{repo}.git/**".to_string()),
+                    patterns: None,
                     description: None,
                     methods: None,
                     subnets: Vec::new(),
@@ -1566,7 +1676,8 @@ mod tests {
                 "needsRepo".to_string(),
                 vec![PolicyRuleTemplateConfig {
                     action: allow_action(),
-                    pattern: "https://gitlab.internal/api/v4/projects/{repo}?**".to_string(),
+                    pattern: Some("https://gitlab.internal/api/v4/projects/{repo}?**".to_string()),
+                    patterns: None,
                     description: None,
                     methods: None,
                     subnets: Vec::new(),
@@ -2307,6 +2418,340 @@ add_url_enc_variants = true
         let msg = format!("{err}");
         assert!(
             msg.contains("Policy macro not found: repo"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    #[test]
+    fn direct_patterns_expand_and_report_matched_effective_pattern() {
+        let toml = r#"
+default = "deny"
+
+[[rules]]
+action = "allow"
+patterns = [
+  "https://example.com/docs/**",
+  "https://example.com/api/**",
+]
+description = "Example grouped rule"
+        "#;
+
+        let cfg: PolicyConfig = toml::from_str(toml).expect("parse policy config");
+        let engine = PolicyEngine::from_config(&cfg).expect("build policy engine");
+
+        assert!(engine.is_allowed("https://example.com/docs/index.html", None, None));
+        let decision = engine.evaluate("https://example.com/api/v1", None, None, &HeaderMap::new());
+
+        assert!(decision.allowed);
+        let matched = decision.matched.expect("matched rule");
+        assert_eq!(matched.index, 1);
+        assert_eq!(
+            matched.pattern.as_deref(),
+            Some("https://example.com/api/**")
+        );
+        assert_eq!(matched.description.as_deref(), Some("Example grouped rule"));
+        assert!(!engine.is_allowed("https://example.com/other", None, None));
+    }
+
+    #[test]
+    fn direct_patterns_preserve_order_and_first_match_wins() {
+        let toml = r#"
+default = "deny"
+
+[[rules]]
+action = "deny"
+patterns = [
+  "https://example.com/admin/**",
+  "https://example.com/private/**",
+]
+
+[[rules]]
+action = "allow"
+pattern = "https://example.com/**"
+        "#;
+
+        let cfg: PolicyConfig = toml::from_str(toml).expect("parse policy config");
+        let engine = PolicyEngine::from_config(&cfg).expect("build policy engine");
+
+        assert!(!engine.is_allowed("https://example.com/admin/settings", None, None));
+        assert!(!engine.is_allowed("https://example.com/private/data", None, None));
+        assert!(engine.is_allowed("https://example.com/public", None, None));
+    }
+
+    #[test]
+    fn direct_patterns_copy_predicates_header_actions_and_external_auth_metadata() {
+        let toml = r#"
+default = "deny"
+
+[external_auth_profiles.example]
+webhook_url = "https://auth.internal/start"
+timeout_ms = 5000
+
+[[rules]]
+action = "allow"
+patterns = [
+  "https://example.com/api/**",
+  "https://example.com/files/**",
+]
+methods = ["GET"]
+headers_absent = ["x-blocked"]
+headers_match = { "x-workload-id" = "worker-123" }
+external_auth_profile = "example"
+request_timeout_ms = 1500
+
+[[rules.header_actions]]
+direction = "request"
+action = "set"
+name = "x-test"
+value = "one"
+        "#;
+
+        let cfg: PolicyConfig = toml::from_str(toml).expect("parse policy config");
+        let engine = PolicyEngine::from_config(&cfg).expect("build policy engine");
+        let headers = header_map(&[("x-workload-id", "worker-123")]);
+        let decision = engine.evaluate(
+            "https://example.com/files/report",
+            None,
+            Some("GET"),
+            &headers,
+        );
+
+        assert!(decision.allowed);
+        let matched = decision.matched.expect("matched rule");
+        assert_eq!(
+            matched.pattern.as_deref(),
+            Some("https://example.com/files/**")
+        );
+        assert_eq!(matched.methods, vec!["GET".to_string()]);
+        assert_eq!(matched.request_timeout_ms, Some(1500));
+        assert_eq!(matched.header_actions.len(), 1);
+        assert_eq!(matched.external_auth_profile.as_deref(), Some("example"));
+
+        let effective = EffectivePolicy::from_config(&cfg).expect("build effective policy");
+        assert_eq!(effective.rules.len(), 2);
+        assert_eq!(
+            effective.rules[0].pattern.as_deref(),
+            Some("https://example.com/api/**")
+        );
+        assert_eq!(
+            effective.rules[1].pattern.as_deref(),
+            Some("https://example.com/files/**")
+        );
+        assert_eq!(effective.rules[1].header_actions.len(), 1);
+        assert_eq!(
+            effective.rules[1]
+                .external_auth
+                .as_ref()
+                .map(|external| external.profile.as_str()),
+            Some("example")
+        );
+    }
+
+    #[test]
+    fn direct_patterns_validation_rejects_invalid_shapes() {
+        let cases = [
+            (
+                r#"
+default = "deny"
+
+[[rules]]
+action = "allow"
+pattern = "https://example.com/**"
+patterns = ["https://example.org/**"]
+                "#,
+                "policy rule must not define both pattern and patterns",
+            ),
+            (
+                r#"
+default = "deny"
+
+[[rules]]
+action = "allow"
+patterns = []
+                "#,
+                "patterns must include at least one pattern",
+            ),
+            (
+                r#"
+default = "deny"
+
+[[rules]]
+action = "allow"
+patterns = ["https://example.com/**", "   "]
+                "#,
+                "patterns entry at index 1 must not be empty",
+            ),
+            (
+                r#"
+default = "deny"
+
+[[rules]]
+action = "allow"
+patterns = ["https://example.com/**", "https://example.org/**"]
+rule_id = "duplicate"
+                "#,
+                "rule_id is not allowed on multi-pattern rules",
+            ),
+        ];
+
+        for (toml, expected) in cases {
+            let cfg: PolicyConfig = toml::from_str(toml).expect("parse policy config");
+            let err = PolicyEngine::from_config(&cfg).expect_err("expected validation error");
+            let msg = format!("{err}");
+            assert!(
+                msg.contains(expected),
+                "expected {expected:?} in error message: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn direct_patterns_trim_entries_and_allow_patternless_header_rules() {
+        let patternless_toml = r#"
+default = "deny"
+
+[[rules]]
+action = "allow"
+headers_match = { "x-workload-id" = "worker-123" }
+        "#;
+        let patternless_cfg: PolicyConfig =
+            toml::from_str(patternless_toml).expect("parse policy config");
+        let patternless =
+            PolicyEngine::from_config(&patternless_cfg).expect("header-only rule remains valid");
+        assert!(patternless.is_allowed_with_headers(
+            "https://example.com/anything",
+            None,
+            None,
+            &header_map(&[("x-workload-id", "worker-123")])
+        ));
+
+        let trimmed_toml = r#"
+default = "deny"
+
+[[rules]]
+action = "allow"
+patterns = ["  https://example.com/docs/**  "]
+        "#;
+        let trimmed_cfg: PolicyConfig = toml::from_str(trimmed_toml).expect("parse policy config");
+        let effective = EffectivePolicy::from_config(&trimmed_cfg).expect("effective policy");
+        assert_eq!(
+            effective.rules[0].pattern.as_deref(),
+            Some("https://example.com/docs/**")
+        );
+    }
+
+    #[test]
+    fn direct_patterns_expand_macros_and_url_encoded_variants() {
+        let toml = r#"
+default = "deny"
+
+[macros]
+repo = ["sip/sipsource", "sip/sipsink"]
+
+[[rules]]
+action = "allow"
+patterns = [
+  "https://gitlab.internal/{repo}.git/**",
+  "https://gitlab.internal/api/v4/projects/{repo}?**",
+]
+add_url_enc_variants = ["repo"]
+        "#;
+
+        let cfg: PolicyConfig = toml::from_str(toml).expect("parse policy config");
+        let engine = PolicyEngine::from_config(&cfg).expect("build policy engine");
+
+        assert!(engine.is_allowed(
+            "https://gitlab.internal/sip/sipsource.git/info/refs",
+            None,
+            None
+        ));
+        assert!(engine.is_allowed(
+            "https://gitlab.internal/api/v4/projects/sip%2Fsipsink?statistics=true",
+            None,
+            None
+        ));
+
+        let effective = EffectivePolicy::from_config(&cfg).expect("effective policy");
+        let patterns = effective
+            .rules
+            .iter()
+            .map(|rule| rule.pattern.as_deref().expect("pattern"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            patterns,
+            vec![
+                "https://gitlab.internal/sip/sipsource.git/**",
+                "https://gitlab.internal/api/v4/projects/sip/sipsource?**",
+                "https://gitlab.internal/sip%2Fsipsource.git/**",
+                "https://gitlab.internal/api/v4/projects/sip%2Fsipsource?**",
+                "https://gitlab.internal/sip/sipsink.git/**",
+                "https://gitlab.internal/api/v4/projects/sip/sipsink?**",
+                "https://gitlab.internal/sip%2Fsipsink.git/**",
+                "https://gitlab.internal/api/v4/projects/sip%2Fsipsink?**",
+            ]
+        );
+    }
+
+    #[test]
+    fn ruleset_template_patterns_expand_and_validate() {
+        let toml = r#"
+default = "deny"
+
+[macros]
+repo = ["sip/sipsource"]
+
+[[rulesets.gitlab]]
+action = "allow"
+patterns = [
+  "https://gitlab.internal/{repo}.git/**",
+  "https://gitlab.internal/api/v4/projects/{repo}?**",
+]
+methods = ["GET"]
+
+[[rules]]
+include = "gitlab"
+add_url_enc_variants = ["repo"]
+        "#;
+
+        let cfg: PolicyConfig = toml::from_str(toml).expect("parse policy config");
+        let effective = EffectivePolicy::from_config(&cfg).expect("effective policy");
+
+        assert_eq!(effective.rules.len(), 4);
+        assert_eq!(
+            effective.rules[0].pattern.as_deref(),
+            Some("https://gitlab.internal/sip/sipsource.git/**")
+        );
+        assert_eq!(
+            effective.rules[1].pattern.as_deref(),
+            Some("https://gitlab.internal/api/v4/projects/sip/sipsource?**")
+        );
+        assert_eq!(
+            effective.rules[2].pattern.as_deref(),
+            Some("https://gitlab.internal/sip%2Fsipsource.git/**")
+        );
+        assert_eq!(
+            effective.rules[3].pattern.as_deref(),
+            Some("https://gitlab.internal/api/v4/projects/sip%2Fsipsource?**")
+        );
+        assert_eq!(effective.rules[0].methods, vec!["GET".to_string()]);
+
+        let invalid_toml = r#"
+default = "deny"
+
+[[rulesets.bad]]
+action = "allow"
+pattern = "https://example.com/**"
+patterns = ["https://example.org/**"]
+
+[[rules]]
+include = "bad"
+        "#;
+        let invalid_cfg: PolicyConfig = toml::from_str(invalid_toml).expect("parse policy config");
+        let err = EffectivePolicy::from_config(&invalid_cfg).expect_err("expected error");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("policy ruleset template must not define both pattern and patterns"),
             "unexpected error message: {msg}"
         );
     }

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -467,26 +467,26 @@ fn expand_direct_rule(
         return Err(PolicyError::RuleInvalid {
             index,
             reason:
-                "policy rule must define at least a pattern, subnets, methods, headers_absent, or headers_match"
+                "policy rule must define at least a pattern, patterns, subnets, methods, headers_absent, or headers_match"
                     .to_string(),
         });
     }
 
     let patterns = patterns.unwrap();
-    let mut placeholders = BTreeSet::new();
-    for pattern in &patterns {
-        collect_placeholders(pattern, &mut placeholders);
-    }
+    let mut extra_placeholders = BTreeSet::new();
     if let Some(desc) = &rule.description {
-        collect_placeholders(desc, &mut placeholders);
+        collect_placeholders(desc, &mut extra_placeholders);
     }
 
     if let Some(rule_id) = &rule.rule_id {
-        collect_placeholders(rule_id, &mut placeholders);
+        collect_placeholders(rule_id, &mut extra_placeholders);
     }
 
-    if placeholders.is_empty() {
-        for pattern in patterns {
+    for pattern in patterns {
+        let mut placeholders = extra_placeholders.clone();
+        collect_placeholders(&pattern, &mut placeholders);
+
+        if placeholders.is_empty() {
             out.push(ExpandedRule {
                 action: rule.action,
                 pattern: Some(pattern),
@@ -500,40 +500,35 @@ fn expand_direct_rule(
                 header_actions: rule.header_actions.clone(),
                 external_auth_profile: rule.external_auth_profile.clone(),
             });
+            continue;
         }
-        return Ok(());
-    }
 
-    let resolved = resolve_placeholders(rule.with.as_ref(), macros, &placeholders, |_| {
-        format!(
-            " (required by direct rule pattern {pattern})",
-            pattern = patterns.join(", ")
-        )
-    })?;
+        let resolved = resolve_placeholders(rule.with.as_ref(), macros, &placeholders, |_| {
+            format!(" (required by direct rule pattern {pattern})")
+        })?;
 
-    let mut combos = cartesian_product(&resolved);
-    let keys_to_vary = keys_for_url_variants(rule.add_url_enc_variants.as_ref(), &placeholders);
-    if !keys_to_vary.is_empty() {
-        combos = add_url_encoded_variants(combos, &keys_to_vary);
-    }
+        let mut combos = cartesian_product(&resolved);
+        let keys_to_vary = keys_for_url_variants(rule.add_url_enc_variants.as_ref(), &placeholders);
+        if !keys_to_vary.is_empty() {
+            combos = add_url_encoded_variants(combos, &keys_to_vary);
+        }
 
-    for combo in combos {
-        let description_interp = rule
-            .description
-            .as_ref()
-            .map(|d| interpolate_template(d, &combo));
-        let rule_id_interp = rule
-            .rule_id
-            .as_ref()
-            .map(|id| interpolate_template(id, &combo));
+        for combo in combos {
+            let pattern_interp = interpolate_template(&pattern, &combo);
+            let description_interp = rule
+                .description
+                .as_ref()
+                .map(|d| interpolate_template(d, &combo));
+            let rule_id_interp = rule
+                .rule_id
+                .as_ref()
+                .map(|id| interpolate_template(id, &combo));
 
-        for pattern in &patterns {
-            let pattern_interp = interpolate_template(pattern, &combo);
             out.push(ExpandedRule {
                 action: rule.action,
                 pattern: Some(pattern_interp),
-                description: description_interp.clone(),
-                rule_id: rule_id_interp.clone(),
+                description: description_interp,
+                rule_id: rule_id_interp,
                 subnets: rule.subnets.clone(),
                 methods: methods.clone(),
                 headers_absent: headers_absent.clone(),
@@ -571,12 +566,19 @@ fn normalize_patterns(
         }
 
         let mut normalized = Vec::with_capacity(patterns.len());
+        let mut seen = BTreeSet::new();
         for (entry_idx, pattern) in patterns.iter().enumerate() {
             let trimmed = pattern.trim();
             if trimmed.is_empty() {
                 return Err(PolicyError::RuleInvalid {
                     index,
                     reason: format!("patterns entry at index {entry_idx} must not be empty"),
+                });
+            }
+            if !seen.insert(trimmed.to_string()) {
+                return Err(PolicyError::RuleInvalid {
+                    index,
+                    reason: format!("patterns entry at index {entry_idx} duplicates an earlier pattern"),
                 });
             }
             normalized.push(trimmed.to_string());
@@ -608,9 +610,8 @@ fn reject_multi_pattern_rule_id(
     if rule_id.is_some() && patterns.is_some_and(|patterns| patterns.len() > 1) {
         return Err(PolicyError::RuleInvalid {
             index,
-            reason:
-                "rule_id is not allowed on multi-pattern rules unless unique effective rule IDs are configured"
-                    .to_string(),
+            reason: "rule_id is not allowed on multi-pattern rules; use one rule per pattern when rule_id is required"
+                .to_string(),
         });
     }
 
@@ -664,11 +665,9 @@ fn expand_include_rule(
         template_patterns.push(TemplatePatterns { template, patterns });
     }
 
-    let mut placeholders = BTreeSet::new();
+    let mut template_extra_placeholders = Vec::with_capacity(template_patterns.len());
     for template_patterns in &template_patterns {
-        for pattern in &template_patterns.patterns {
-            collect_placeholders(pattern, &mut placeholders);
-        }
+        let mut placeholders = BTreeSet::new();
         let template = template_patterns.template;
         if let Some(desc) = &template.description {
             collect_placeholders(desc, &mut placeholders);
@@ -676,23 +675,29 @@ fn expand_include_rule(
         if let Some(rule_id) = &template.rule_id {
             collect_placeholders(rule_id, &mut placeholders);
         }
+        template_extra_placeholders.push(placeholders);
     }
 
-    if placeholders.is_empty() {
-        for template_patterns in &template_patterns {
-            let template = template_patterns.template;
-            let headers_absent =
-                validate_headers_absent(template.headers_absent.as_deref(), index)?;
-            let headers_match = validate_headers_match(template.headers_match.as_ref(), index)?;
-            let methods = rule
-                .methods
-                .as_ref()
-                .map(|m| m.as_slice().to_vec())
-                .or_else(|| template.methods.as_ref().map(|m| m.as_slice().to_vec()))
-                .unwrap_or_default();
-            let request_timeout_ms = rule.request_timeout_ms.or(template.request_timeout_ms);
+    for (template_patterns, extra_placeholders) in template_patterns
+        .iter()
+        .zip(template_extra_placeholders.iter())
+    {
+        let template = template_patterns.template;
+        let headers_absent = validate_headers_absent(template.headers_absent.as_deref(), index)?;
+        let headers_match = validate_headers_match(template.headers_match.as_ref(), index)?;
+        let methods = rule
+            .methods
+            .as_ref()
+            .map(|m| m.as_slice().to_vec())
+            .or_else(|| template.methods.as_ref().map(|m| m.as_slice().to_vec()))
+            .unwrap_or_default();
+        let request_timeout_ms = rule.request_timeout_ms.or(template.request_timeout_ms);
 
-            for pattern in &template_patterns.patterns {
+        for pattern in &template_patterns.patterns {
+            let mut placeholders = extra_placeholders.clone();
+            collect_placeholders(pattern, &mut placeholders);
+
+            if placeholders.is_empty() {
                 out.push(ExpandedRule {
                     action: template.action,
                     pattern: Some(pattern.clone()),
@@ -710,51 +715,36 @@ fn expand_include_rule(
                     header_actions: template.header_actions.clone(),
                     external_auth_profile: template.external_auth_profile.clone(),
                 });
+                continue;
             }
-        }
-        return Ok(());
-    }
 
-    let resolved = resolve_placeholders(rule.with.as_ref(), macros, &placeholders, |_| {
-        format!(" (required by ruleset {ruleset})", ruleset = rule.include)
-    })?;
+            let resolved = resolve_placeholders(rule.with.as_ref(), macros, &placeholders, |_| {
+                format!(" (required by ruleset {ruleset})", ruleset = rule.include)
+            })?;
 
-    let mut combos = cartesian_product(&resolved);
-    let keys_to_vary = keys_for_url_variants(rule.add_url_enc_variants.as_ref(), &placeholders);
-    if !keys_to_vary.is_empty() {
-        combos = add_url_encoded_variants(combos, &keys_to_vary);
-    }
+            let mut combos = cartesian_product(&resolved);
+            let keys_to_vary =
+                keys_for_url_variants(rule.add_url_enc_variants.as_ref(), &placeholders);
+            if !keys_to_vary.is_empty() {
+                combos = add_url_encoded_variants(combos, &keys_to_vary);
+            }
 
-    for combo in combos {
-        for template_patterns in &template_patterns {
-            let template = template_patterns.template;
-            let headers_absent =
-                validate_headers_absent(template.headers_absent.as_deref(), index)?;
-            let headers_match = validate_headers_match(template.headers_match.as_ref(), index)?;
-            let methods = rule
-                .methods
-                .as_ref()
-                .map(|m| m.as_slice().to_vec())
-                .or_else(|| template.methods.as_ref().map(|m| m.as_slice().to_vec()))
-                .unwrap_or_default();
-            let request_timeout_ms = rule.request_timeout_ms.or(template.request_timeout_ms);
-
-            let description_interp = template
-                .description
-                .as_ref()
-                .map(|d| interpolate_template(d, &combo));
-            let rule_id_interp = template
-                .rule_id
-                .as_ref()
-                .map(|id| interpolate_template(id, &combo));
-
-            for pattern in &template_patterns.patterns {
+            for combo in combos {
                 let pattern_interp = interpolate_template(pattern, &combo);
+                let description_interp = template
+                    .description
+                    .as_ref()
+                    .map(|d| interpolate_template(d, &combo));
+                let rule_id_interp = template
+                    .rule_id
+                    .as_ref()
+                    .map(|id| interpolate_template(id, &combo));
+
                 out.push(ExpandedRule {
                     action: template.action,
                     pattern: Some(pattern_interp),
-                    description: description_interp.clone(),
-                    rule_id: rule_id_interp.clone(),
+                    description: description_interp,
+                    rule_id: rule_id_interp,
                     subnets: if !rule.subnets.is_empty() {
                         rule.subnets.clone()
                     } else {
@@ -2587,6 +2577,16 @@ default = "deny"
 
 [[rules]]
 action = "allow"
+patterns = ["https://example.com/**", " https://example.com/** "]
+                "#,
+                "patterns entry at index 1 duplicates an earlier pattern",
+            ),
+            (
+                r#"
+default = "deny"
+
+[[rules]]
+action = "allow"
 patterns = ["https://example.com/**", "https://example.org/**"]
 rule_id = "duplicate"
                 "#,
@@ -2682,13 +2682,48 @@ add_url_enc_variants = ["repo"]
             patterns,
             vec![
                 "https://gitlab.internal/sip/sipsource.git/**",
-                "https://gitlab.internal/api/v4/projects/sip/sipsource?**",
                 "https://gitlab.internal/sip%2Fsipsource.git/**",
-                "https://gitlab.internal/api/v4/projects/sip%2Fsipsource?**",
                 "https://gitlab.internal/sip/sipsink.git/**",
-                "https://gitlab.internal/api/v4/projects/sip/sipsink?**",
                 "https://gitlab.internal/sip%2Fsipsink.git/**",
+                "https://gitlab.internal/api/v4/projects/sip/sipsource?**",
+                "https://gitlab.internal/api/v4/projects/sip%2Fsipsource?**",
+                "https://gitlab.internal/api/v4/projects/sip/sipsink?**",
                 "https://gitlab.internal/api/v4/projects/sip%2Fsipsink?**",
+            ]
+        );
+    }
+
+    #[test]
+    fn direct_patterns_with_divergent_placeholders_match_duplicated_rule_behavior() {
+        let toml = r#"
+default = "deny"
+
+[macros]
+tenant = ["tenant-a"]
+repo = ["service-a", "service-b"]
+
+[[rules]]
+action = "allow"
+patterns = [
+  "https://example.com/static/{tenant}/**",
+  "https://example.com/repos/{repo}/**",
+]
+        "#;
+
+        let cfg: PolicyConfig = toml::from_str(toml).expect("parse policy config");
+        let effective = EffectivePolicy::from_config(&cfg).expect("effective policy");
+        let patterns = effective
+            .rules
+            .iter()
+            .map(|rule| rule.pattern.as_deref().expect("pattern"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            patterns,
+            vec![
+                "https://example.com/static/tenant-a/**",
+                "https://example.com/repos/service-a/**",
+                "https://example.com/repos/service-b/**",
             ]
         );
     }
@@ -2712,6 +2747,9 @@ methods = ["GET"]
 [[rules]]
 include = "gitlab"
 add_url_enc_variants = ["repo"]
+methods = ["POST"]
+subnets = ["10.0.0.0/8"]
+request_timeout_ms = 2500
         "#;
 
         let cfg: PolicyConfig = toml::from_str(toml).expect("parse policy config");
@@ -2724,17 +2762,24 @@ add_url_enc_variants = ["repo"]
         );
         assert_eq!(
             effective.rules[1].pattern.as_deref(),
-            Some("https://gitlab.internal/api/v4/projects/sip/sipsource?**")
+            Some("https://gitlab.internal/sip%2Fsipsource.git/**")
         );
         assert_eq!(
             effective.rules[2].pattern.as_deref(),
-            Some("https://gitlab.internal/sip%2Fsipsource.git/**")
+            Some("https://gitlab.internal/api/v4/projects/sip/sipsource?**")
         );
         assert_eq!(
             effective.rules[3].pattern.as_deref(),
             Some("https://gitlab.internal/api/v4/projects/sip%2Fsipsource?**")
         );
-        assert_eq!(effective.rules[0].methods, vec!["GET".to_string()]);
+        for rule in &effective.rules {
+            assert_eq!(rule.methods, vec!["POST".to_string()]);
+            assert_eq!(
+                rule.subnets.iter().map(|subnet| subnet.to_string()).collect::<Vec<_>>(),
+                vec!["10.0.0.0/8".to_string()]
+            );
+            assert_eq!(rule.request_timeout_ms, Some(2500));
+        }
 
         let invalid_toml = r#"
 default = "deny"
@@ -2752,6 +2797,25 @@ include = "bad"
         let msg = format!("{err}");
         assert!(
             msg.contains("policy ruleset template must not define both pattern and patterns"),
+            "unexpected error message: {msg}"
+        );
+
+        let rule_id_toml = r#"
+default = "deny"
+
+[[rulesets.bad]]
+action = "allow"
+patterns = ["https://example.com/**", "https://example.org/**"]
+rule_id = "duplicate"
+
+[[rules]]
+include = "bad"
+        "#;
+        let rule_id_cfg: PolicyConfig = toml::from_str(rule_id_toml).expect("parse policy config");
+        let err = EffectivePolicy::from_config(&rule_id_cfg).expect_err("expected error");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("rule_id is not allowed on multi-pattern rules"),
             "unexpected error message: {msg}"
         );
     }

--- a/tests/config_reload.rs
+++ b/tests/config_reload.rs
@@ -179,6 +179,7 @@ async fn loop_header_injection_updates_after_reload() {
                 upstream_addr.ip(),
                 upstream_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -264,6 +265,7 @@ async fn failed_reload_keeps_previous_state() {
                 upstream_addr.ip(),
                 upstream_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -416,6 +418,7 @@ async fn egress_forwarding_enable_disable_updates_after_reload() {
                 direct_addr.ip(),
                 direct_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),

--- a/tests/egress_forwarding_chain.rs
+++ b/tests/egress_forwarding_chain.rs
@@ -185,6 +185,7 @@ fn allow_rule(pattern: String, header_actions: Vec<HeaderActionConfig>) -> Polic
     PolicyRuleConfig::Direct(PolicyRuleDirectConfig {
         action: PolicyDefaultAction::Allow,
         pattern: Some(pattern),
+        patterns: None,
         description: None,
         methods: None,
         subnets: Vec::new(),

--- a/tests/policy_cli.rs
+++ b/tests/policy_cli.rs
@@ -230,6 +230,106 @@ subnets = ["10.0.0.0/8"]
 }
 
 #[test]
+fn policy_dump_json_expands_patterns_to_singular_effective_rules() {
+    let mut file = NamedTempFile::new().expect("create temp config");
+    file.write_all(
+        br#"
+schema_version = "1"
+
+[proxy]
+bind_address = "127.0.0.1"
+http_port = 8080
+
+[logging]
+directory = "logs"
+level = "info"
+
+[policy]
+default = "deny"
+
+[[policy.rules]]
+action = "allow"
+patterns = [
+  "https://developers.openai.com/**",
+  "https://github.com/openai/**",
+]
+methods = ["GET"]
+description = "OpenAI docs and repositories"
+        "#,
+    )
+    .expect("write config");
+
+    let mut cmd = Command::new(assert_cmd::cargo_bin!("acl-proxy"));
+    cmd.arg("policy")
+        .arg("dump")
+        .arg("--format")
+        .arg("json")
+        .arg("--config")
+        .arg(file.path());
+
+    let assert = cmd.assert().success();
+    let stdout =
+        String::from_utf8(assert.get_output().stdout.clone()).expect("stdout is valid UTF-8");
+    let value: Value = serde_json::from_str(&stdout).expect("output is valid JSON");
+    let rules = value["rules"].as_array().expect("rules is an array");
+
+    assert_eq!(rules.len(), 2);
+    assert_eq!(rules[0]["index"], 0);
+    assert_eq!(rules[0]["pattern"], "https://developers.openai.com/**");
+    assert_eq!(rules[0]["description"], "OpenAI docs and repositories");
+    assert_eq!(rules[1]["index"], 1);
+    assert_eq!(rules[1]["pattern"], "https://github.com/openai/**");
+    assert_eq!(rules[1]["description"], "OpenAI docs and repositories");
+    assert!(rules[0].get("patterns").is_none());
+}
+
+#[test]
+fn policy_dump_table_expands_patterns_to_rows() {
+    let mut file = NamedTempFile::new().expect("create temp config");
+    file.write_all(
+        br#"
+schema_version = "1"
+
+[proxy]
+bind_address = "127.0.0.1"
+http_port = 8080
+
+[logging]
+directory = "logs"
+level = "info"
+
+[policy]
+default = "deny"
+
+[[policy.rules]]
+action = "allow"
+patterns = [
+  "https://developers.openai.com/**",
+  "https://github.com/openai/**",
+]
+headers_match = { "x-workload-id" = "worker-123" }
+description = "OpenAI docs and repositories"
+        "#,
+    )
+    .expect("write config");
+
+    let mut cmd = Command::new(assert_cmd::cargo_bin!("acl-proxy"));
+    cmd.arg("policy")
+        .arg("dump")
+        .arg("--format")
+        .arg("table")
+        .arg("--config")
+        .arg(file.path());
+
+    cmd.assert()
+        .success()
+        .stdout(contains("https://developers.openai.com/**"))
+        .stdout(contains("https://github.com/openai/**"))
+        .stdout(contains("x-workload-id=worker-123"))
+        .stdout(contains("OpenAI docs and repositories"));
+}
+
+#[test]
 fn policy_dump_json_includes_headers_absent() {
     let mut file = NamedTempFile::new().expect("create temp config");
     file.write_all(

--- a/tests/proxy_http.rs
+++ b/tests/proxy_http.rs
@@ -761,6 +761,7 @@ async fn allowed_request_uses_configured_egress_forwarding_destination() {
         acl_proxy::config::PolicyRuleDirectConfig {
             action: acl_proxy::config::PolicyDefaultAction::Allow,
             pattern: Some("http://example.invalid/**".to_string()),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -821,6 +822,7 @@ async fn global_egress_request_actions_are_applied_after_rule_actions_without_af
         acl_proxy::config::PolicyRuleConfig::Direct(acl_proxy::config::PolicyRuleDirectConfig {
             action: acl_proxy::config::PolicyDefaultAction::Deny,
             pattern: Some("http://example.invalid/**".to_string()),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -836,6 +838,7 @@ async fn global_egress_request_actions_are_applied_after_rule_actions_without_af
         acl_proxy::config::PolicyRuleConfig::Direct(acl_proxy::config::PolicyRuleDirectConfig {
             action: acl_proxy::config::PolicyDefaultAction::Allow,
             pattern: Some("http://example.invalid/**".to_string()),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -982,6 +985,7 @@ async fn global_egress_request_actions_respect_intra_layer_order() {
         acl_proxy::config::PolicyRuleDirectConfig {
             action: acl_proxy::config::PolicyDefaultAction::Allow,
             pattern: Some("http://example.invalid/**".to_string()),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -1070,6 +1074,7 @@ async fn empty_global_egress_actions_preserve_existing_rule_header_behavior() {
         acl_proxy::config::PolicyRuleDirectConfig {
             action: acl_proxy::config::PolicyDefaultAction::Allow,
             pattern: Some("http://example.invalid/**".to_string()),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -1404,6 +1409,7 @@ async fn http_explicit_listener_accepts_h2c_prior_knowledge_requests() {
                 upstream_addr.ip(),
                 upstream_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -1449,6 +1455,7 @@ async fn allowed_request_is_proxied_and_loop_header_added() {
                 upstream_addr.ip(),
                 upstream_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -1512,6 +1519,7 @@ async fn headers_absent_top_deny_guard_falls_through_to_allow_rule() {
         acl_proxy::config::PolicyRuleConfig::Direct(acl_proxy::config::PolicyRuleDirectConfig {
             action: acl_proxy::config::PolicyDefaultAction::Deny,
             pattern: Some(format!("http://{host}/**")),
+            patterns: None,
             description: Some("Deny requests missing identity".to_string()),
             methods: None,
             subnets: Vec::new(),
@@ -1527,6 +1535,7 @@ async fn headers_absent_top_deny_guard_falls_through_to_allow_rule() {
         acl_proxy::config::PolicyRuleConfig::Direct(acl_proxy::config::PolicyRuleDirectConfig {
             action: acl_proxy::config::PolicyDefaultAction::Allow,
             pattern: Some(format!("http://{host}/**")),
+            patterns: None,
             description: Some("Allow upstream traffic".to_string()),
             methods: None,
             subnets: Vec::new(),
@@ -1593,6 +1602,7 @@ async fn method_scoped_headers_absent_guard_only_blocks_matching_methods() {
         acl_proxy::config::PolicyRuleConfig::Direct(acl_proxy::config::PolicyRuleDirectConfig {
             action: acl_proxy::config::PolicyDefaultAction::Deny,
             pattern: Some(format!("http://{host}/**")),
+            patterns: None,
             description: Some("Deny POSTs missing identity".to_string()),
             methods: Some({
                 #[derive(serde::Deserialize)]
@@ -1617,6 +1627,7 @@ async fn method_scoped_headers_absent_guard_only_blocks_matching_methods() {
         acl_proxy::config::PolicyRuleConfig::Direct(acl_proxy::config::PolicyRuleDirectConfig {
             action: acl_proxy::config::PolicyDefaultAction::Allow,
             pattern: Some(format!("http://{host}/**")),
+            patterns: None,
             description: Some("Allow upstream traffic".to_string()),
             methods: None,
             subnets: Vec::new(),
@@ -1682,6 +1693,7 @@ async fn headers_match_top_guard_denies_non_matching_value_and_allows_matching_v
         acl_proxy::config::PolicyRuleConfig::Direct(acl_proxy::config::PolicyRuleDirectConfig {
             action: acl_proxy::config::PolicyDefaultAction::Allow,
             pattern: Some(format!("http://{host}/**")),
+            patterns: None,
             description: Some("Allow trusted identity header".to_string()),
             methods: None,
             subnets: Vec::new(),
@@ -1700,6 +1712,7 @@ async fn headers_match_top_guard_denies_non_matching_value_and_allows_matching_v
         acl_proxy::config::PolicyRuleConfig::Direct(acl_proxy::config::PolicyRuleDirectConfig {
             action: acl_proxy::config::PolicyDefaultAction::Deny,
             pattern: Some(format!("http://{host}/**")),
+            patterns: None,
             description: Some("Deny all other traffic".to_string()),
             methods: None,
             subnets: Vec::new(),
@@ -1764,6 +1777,7 @@ async fn headers_match_http_regressions_cover_repeated_values_comma_literals_and
         acl_proxy::config::PolicyRuleDirectConfig {
             action: acl_proxy::config::PolicyDefaultAction::Allow,
             pattern: Some(format!("http://{host}/**")),
+            patterns: None,
             description: Some("Allow only exact trusted header values".to_string()),
             methods: None,
             subnets: Vec::new(),
@@ -1852,6 +1866,7 @@ async fn loop_header_not_added_when_disabled() {
                 upstream_addr.ip(),
                 upstream_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -2001,6 +2016,7 @@ async fn origin_form_request_with_host_is_forwarded() {
         acl_proxy::config::PolicyRuleDirectConfig {
             action: acl_proxy::config::PolicyDefaultAction::Allow,
             pattern: Some(format!("http://{host}/**")),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -2064,6 +2080,7 @@ async fn upstream_connection_failure_returns_502() {
         acl_proxy::config::PolicyRuleDirectConfig {
             action: acl_proxy::config::PolicyDefaultAction::Allow,
             pattern: Some("http://127.0.0.1:1/**".to_string()),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -2113,6 +2130,7 @@ async fn upstream_request_timeout_returns_504() {
                 upstream_addr.ip(),
                 upstream_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),

--- a/tests/proxy_https_connect.rs
+++ b/tests/proxy_https_connect.rs
@@ -341,6 +341,7 @@ async fn allowed_https_via_connect_is_proxied_and_captured() {
                 upstream_addr.ip(),
                 upstream_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -427,6 +428,7 @@ async fn configured_egress_forwarding_applies_to_https_connect_inner_requests() 
         acl_proxy::config::PolicyRuleDirectConfig {
             action: acl_proxy::config::PolicyDefaultAction::Allow,
             pattern: Some("https://connect-target.test:9443/**".to_string()),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -485,6 +487,7 @@ async fn global_egress_request_actions_apply_to_https_connect_inner_requests() {
         acl_proxy::config::PolicyRuleDirectConfig {
             action: acl_proxy::config::PolicyDefaultAction::Allow,
             pattern: Some("https://connect-target.test:9443/**".to_string()),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -555,6 +558,7 @@ async fn denied_https_via_connect_returns_403() {
                 upstream_addr.ip(),
                 upstream_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -602,6 +606,7 @@ async fn headers_match_is_evaluated_on_decrypted_inner_connect_requests() {
         acl_proxy::config::PolicyRuleDirectConfig {
             action: acl_proxy::config::PolicyDefaultAction::Allow,
             pattern: Some("https://connect-target.test:9443/**".to_string()),
+            patterns: None,
             description: Some("Allow trusted workload identities".to_string()),
             methods: None,
             subnets: Vec::new(),
@@ -690,6 +695,7 @@ async fn loop_detected_on_connect_returns_508() {
                 upstream_addr.ip(),
                 upstream_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),

--- a/tests/proxy_https_transparent.rs
+++ b/tests/proxy_https_transparent.rs
@@ -688,6 +688,7 @@ async fn allowed_https_transparent_is_proxied_and_captured() {
                 upstream_addr.ip(),
                 upstream_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -782,6 +783,7 @@ async fn configured_egress_forwarding_applies_to_https_transparent_requests() {
         acl_proxy::config::PolicyRuleDirectConfig {
             action: acl_proxy::config::PolicyDefaultAction::Allow,
             pattern: Some("https://transparent-target.test:9443/**".to_string()),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -847,6 +849,7 @@ async fn global_egress_request_actions_apply_to_https_transparent_requests() {
         acl_proxy::config::PolicyRuleDirectConfig {
             action: acl_proxy::config::PolicyDefaultAction::Allow,
             pattern: Some("https://transparent-target.test:9443/**".to_string()),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -925,6 +928,7 @@ async fn transparent_https_websocket_upgrade_is_tunneled() {
                 upstream_addr.ip(),
                 upstream_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -1048,6 +1052,7 @@ async fn allowed_https_transparent_h2_is_proxied_and_captured() {
                 upstream_addr.ip(),
                 upstream_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -1162,6 +1167,7 @@ async fn upstream_failure_https_transparent_is_captured() {
                 upstream_addr.ip(),
                 upstream_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -1273,6 +1279,7 @@ async fn concurrent_h2_streams_share_connection_and_are_captured() {
                 upstream_addr.ip(),
                 upstream_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -1472,6 +1479,7 @@ async fn concurrent_h2_streams_mixed_allow_and_deny() {
                 upstream_addr.ip(),
                 upstream_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -1684,6 +1692,7 @@ async fn large_h2_request_body_is_truncated_in_capture() {
                 upstream_addr.ip(),
                 upstream_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -1810,6 +1819,7 @@ async fn large_h2_response_body_is_truncated_in_capture() {
                 upstream_addr.ip(),
                 upstream_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -1940,6 +1950,7 @@ async fn h2_client_to_http1_only_upstream_preserves_versions_in_capture() {
                 upstream_addr.ip(),
                 upstream_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -2061,6 +2072,7 @@ async fn h2_client_to_h2_capable_upstream_preserves_h2_in_capture() {
                 upstream_addr.ip(),
                 upstream_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -2178,6 +2190,7 @@ async fn denied_https_transparent_returns_403() {
                 upstream_addr.ip(),
                 upstream_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),
@@ -2307,6 +2320,7 @@ async fn denied_https_transparent_h2_returns_403() {
                 upstream_addr.ip(),
                 upstream_addr.port()
             )),
+            patterns: None,
             description: None,
             methods: None,
             subnets: Vec::new(),


### PR DESCRIPTION
## Summary
- add patterns = [...] to direct rules and ruleset templates
- expand plural patterns into singular effective rules before compilation
- preserve singular policy dump/log output and first-match-wins runtime behavior
- validate empty, duplicate, mixed pattern/patterns, and multi-pattern rule_id cases

## Tests
- cargo fmt
- cargo clippy
- cargo test
- cargo build --release
