### PR TITLE
Add delegate policy action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## [Unreleased]
 
 ### Breaking Changes
-- Require external authorization rules to use `action = "delegate"`; `external_auth_profile` is now rejected on local `allow` and `deny` rules.
+- Require external authorization rules to use `action = "delegate"`; `external_auth_profile` is now rejected on local `allow` and `deny` rules ([#49](https://github.com/kcosr/acl-proxy/pull/49)).
 
 ### Added
 - Add `patterns = [...]` policy rule support for expanding several URL patterns with shared rule attributes into singular effective rules ([#48](https://github.com/kcosr/acl-proxy/pull/48)).
-- Add first-class `delegate` policy rules and `pass` external-auth decisions so HTTP and plugin providers can continue evaluation at the next policy rule.
+- Add first-class `delegate` policy rules and `pass` external-auth decisions so HTTP and plugin providers can continue evaluation at the next policy rule ([#49](https://github.com/kcosr/acl-proxy/pull/49)).
 
 ## [0.0.12] - 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+- Require external authorization rules to use `action = "delegate"`; `external_auth_profile` is now rejected on local `allow` and `deny` rules.
+
 ### Added
 - Add `patterns = [...]` policy rule support for expanding several URL patterns with shared rule attributes into singular effective rules ([#48](https://github.com/kcosr/acl-proxy/pull/48)).
+- Add first-class `delegate` policy rules and `pass` external-auth decisions so HTTP and plugin providers can continue evaluation at the next policy rule.
 
 ## [0.0.12] - 2026-03-19
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # acl-proxy
 
-A Rust-based ACL-aware HTTP/HTTPS proxy with a TOML configuration file and a flexible URL policy engine. Evaluate every request against ordered rules matching on URL patterns, HTTP methods, client subnets, and headers — then allow, deny, or gate behind an external approval workflow.
+A Rust-based ACL-aware HTTP/HTTPS proxy with a TOML configuration file and a flexible URL policy engine. Evaluate every request against ordered rules matching on URL patterns, HTTP methods, client subnets, and headers — then allow, deny, or delegate to an external auth workflow.
 
 ## Table of Contents
 
@@ -33,7 +33,7 @@ graph TB
         HTTPS["Transparent HTTPS Listener<br/>:8889"]
         LP["Loop Protection"]
         PE["Policy Engine<br/>pattern · method · subnet · headers"]
-        EA["External Auth<br/>(optional approval gate)"]
+        EA["External Auth<br/>(delegate rules)"]
         HA["Header Actions<br/>request · response mutations"]
         EF["Egress Forwarding<br/>(optional chained proxy)"]
     end
@@ -45,14 +45,17 @@ graph TB
     HTTP --> LP
     HTTPS --> LP
     LP --> PE
-    PE -->|allow| EA
+    PE -->|allow| HA
+    PE -->|delegate| EA
     PE -->|deny| Deny["403 Forbidden"]
-    EA -->|approved| HA
+    EA -->|allow| HA
+    EA -->|deny| Deny
+    EA -.->|pass: continue rules| PE
     HA --> EF
     EF --> Upstream
 ```
 
-**Policy evaluation order** for each rule: pattern → subnets → methods → `headers_absent` → `headers_match`. First match wins; if nothing matches, `policy.default` applies.
+**Policy evaluation order** for each rule: pattern → subnets → methods → `headers_absent` → `headers_match`. Local `allow`/`deny` matches are terminal. A matched `delegate` rule calls external auth; external `pass` continues with the next rule, and if nothing later matches, `policy.default` applies.
 
 ## Quick Start
 
@@ -166,13 +169,16 @@ sequenceDiagram
         Policy-->>Client: 403 Forbidden (+ capture if configured)
     end
 
-    alt Allowed + external auth gate
-        Policy->>Auth: Send approval webhook
-        Auth-->>Policy: Callback with decision
+    alt Delegate rule
+        Policy->>Auth: Send webhook or plugin request
+        Auth-->>Policy: allow / deny / pass
+        opt pass
+            Policy->>Policy: Resume at next rule
+        end
     end
 
-    Policy->>Headers: Apply rule request header actions
-    Headers->>Headers: Apply plugin request header actions (if any)
+    Policy->>Headers: Apply rule request header actions on allow
+    Headers->>Headers: Apply provider/plugin request header actions on external allow
     Headers->>Headers: Apply global egress request header actions
     Headers->>Upstream: Forward request
     Upstream-->>Headers: Response
@@ -231,7 +237,7 @@ When `[proxy.egress.default]` is configured, allowed proxied requests from all m
 
 ## Policy Engine
 
-The policy engine evaluates each request against an ordered list of rules and returns the first match. If no rule matches, `policy.default` applies. Invalid or unparseable URLs are always denied.
+The policy engine evaluates each request against an ordered list of rules. `allow` and `deny` rules are terminal local decisions. `delegate` rules call an external auth profile, whose decision can allow, deny, or pass so evaluation continues at the next rule. If no rule matches, `policy.default` applies. Invalid or unparseable URLs are always denied.
 
 ### Rule Evaluation Order
 
@@ -244,7 +250,7 @@ The policy engine evaluates each request against an ordered list of rules and re
    - Method match (if set)
    - `headers_absent` match (if set)
    - `headers_match` match (if set)
-5. First match wins.
+5. The first `allow` or `deny` match wins. A matched `delegate` rule wins only when the external auth provider returns `allow` or `deny`.
 6. If nothing matches, apply `policy.default`.
 
 All predicates use AND semantics — a rule matches only when every predicate passes.
@@ -454,12 +460,12 @@ when = "always"
 
 Ordering for outbound requests:
 1. Evaluate policy and match the first rule.
-2. Apply matched-rule request header actions.
-3. Apply plugin request header actions (when present).
+2. For a local `allow`, apply matched-rule request header actions. For `delegate`, apply matched-rule request header actions only if the provider returns `allow`.
+3. Apply provider/plugin request header actions only on external `allow`.
 4. Apply global egress request header actions.
 5. Send upstream.
 
-Global egress actions never affect rule matching. Their `when` conditions are evaluated against header presence at the start of the global layer (after rule/plugin actions). Global response-header actions are not supported — only request-direction actions are available in this layer.
+Global egress actions never affect rule matching. Their `when` conditions are evaluated against header presence at the start of the global layer (after rule/provider actions). On external `pass`, no rule or provider header actions are applied and later policy rules evaluate the original request headers. Global response-header actions are not supported — only request-direction actions are available in this layer.
 
 ### Debugging Policies
 
@@ -680,7 +686,7 @@ See [Policy Engine](#policy-engine) for full details on rules, macros, rulesets,
 
 ```toml
 [[policy.rules]]
-action = "allow"                    # required: "allow" | "deny"
+action = "allow"                    # required: "allow" | "deny" | "delegate"
 pattern = "https://example.com/**"  # optional: URL pattern
 # patterns = ["https://a/**"]       # optional alternative: multiple URL patterns
 description = "Example rule"        # optional
@@ -690,10 +696,11 @@ headers_absent = ["x-id"]          # optional: missing-header check
 headers_match = { "x-id" = "v1" }  # optional: exact header match
 request_timeout_ms = 5000          # optional: override upstream timeout
 rule_id = "stable-id"             # optional: stable ID for webhooks
-external_auth_profile = "name"     # optional: approval gate (allow rules only)
+external_auth_profile = "name"     # required for delegate; invalid for allow/deny
 ```
 
 At least one of `pattern`, `patterns`, `methods`, `subnets`, `headers_absent`, or `headers_match` must be present.
+`allow` and `deny` are terminal local decisions. `delegate` invokes the named HTTP or plugin external auth profile; the provider can return `allow` or `deny` as terminal decisions, or `pass` to continue policy evaluation at the next rule.
 
 #### Include Rule Fields
 
@@ -775,13 +782,15 @@ The config loader performs validation beyond basic TOML parsing:
 - `ca_key_path` and `ca_cert_path` must be both set or both omitted.
 - `loop_protection.header_name` must be a valid HTTP header name.
 - `${NAME}` env placeholders must resolve at validation/startup/reload time. Existing literal `${...}` strings in `set`/`add` header-action values are reserved syntax and must be migrated.
-- `external_auth_profile` on `action = "deny"` rules is rejected — approval-required deny rules are not allowed.
+- `policy.default` must be `allow` or `deny`; `delegate` is valid only on rules and ruleset templates.
+- `action = "delegate"` requires `external_auth_profile`.
+- `external_auth_profile` on `action = "allow"` or `action = "deny"` rules is rejected.
 
 On validation failure, `config validate` and startup report a human-readable error and abort, leaving any previously running instance (in the case of reload) unchanged.
 
 ## External Auth
 
-External auth turns `allow` rules into approval-required gates. When a matching request hits an approval-gated rule, acl-proxy pauses the request, sends a webhook to an external service, and waits for a callback decision.
+External auth is invoked by `delegate` policy rules. When a matching request hits a delegate rule, acl-proxy pauses the request, sends a webhook to an HTTP external auth service or invokes a stdio plugin, and waits for a decision.
 
 ```mermaid
 sequenceDiagram
@@ -790,14 +799,16 @@ sequenceDiagram
     participant Approver as External Auth Service
 
     Client->>Proxy: HTTPS request
-    Proxy->>Proxy: Policy match → approval required
+    Proxy->>Proxy: Policy match → delegate
     Proxy->>Approver: POST webhook (X-Acl-Proxy-Event: pending)
     Note over Proxy: Waiting for callback...
     Approver->>Proxy: POST /_acl-proxy/external-auth/callback
-    Note over Approver: approve / deny
-    alt Approved
+    Note over Approver: allow / deny / pass
+    alt Allowed
         Proxy->>Proxy: Interpolate approval macros into headers
         Proxy-->>Client: Forward upstream response
+    else Passed
+        Proxy->>Proxy: Continue policy evaluation at next rule
     else Denied / Timeout
         Proxy-->>Client: 403 Forbidden / 504 Timeout
     end
@@ -805,7 +816,7 @@ sequenceDiagram
 
 ### Webhook Format
 
-When a rule with `external_auth_profile` matches, the proxy POSTs a webhook:
+When a `delegate` rule with `external_auth_profile` matches an HTTP profile, the proxy POSTs a webhook:
 
 - **URL**: `policy.external_auth_profiles.<name>.webhook_url`
 - **Header**: `X-Acl-Proxy-Event: pending`
@@ -828,7 +839,7 @@ Content-Type: application/json
 
 {
   "requestId": "req-...",
-  "decision": "allow" | "deny",
+  "decision": "allow" | "deny" | "pass",
   "macros": {
     "github_token": "ghp_...",
     "reason": "Approving for test"
@@ -842,11 +853,11 @@ Content-Type: application/json
 | `404 Not Found` | Unknown or already completed `requestId` |
 | `400 Bad Request` | Invalid body or missing required macros |
 
-**Macro validation**: Required macros must be present and non-empty. Values must not contain control characters (ASCII < 0x20 or DEL). Optional macros may be omitted or empty.
+**Macro validation**: Required macros must be present and non-empty for `allow` decisions. Values must not contain control characters (ASCII < 0x20 or DEL). Optional macros may be omitted or empty. `pass` decisions do not apply approval macro substitutions or header actions; policy evaluation resumes at the rule after the matched delegate rule.
 
 ### Plugin Mode (type = "plugin")
 
-Stdio-based synchronous auth. The proxy spawns a long-running plugin process and sends JSON requests over stdin, waiting for allow/deny JSON responses from stdout (newline-delimited). On allow, the proxy applies rule header actions first, plugin header actions second, and global egress request actions third. Plugins can also return response header actions. See [`docs/design/auth-plugins-design.md`](docs/design/auth-plugins-design.md) for the full protocol specification.
+Stdio-based synchronous auth. The proxy spawns a long-running plugin process and sends JSON requests over stdin, waiting for `allow`, `deny`, or `pass` JSON responses from stdout (newline-delimited). On `allow`, the proxy applies rule header actions first, plugin header actions second, and global egress request actions third. On `pass`, the plugin must not return request or response header actions, and policy evaluation resumes at the rule after the matched delegate rule. Plugins can also return response header actions on `allow`. See [`docs/design/auth-plugins-design.md`](docs/design/auth-plugins-design.md) for the full protocol specification.
 
 ### Failure Handling
 

--- a/acl-proxy.sample.toml
+++ b/acl-proxy.sample.toml
@@ -303,7 +303,7 @@ subnets = ["127.0.0.0/8"]
 
 [[policy.rules]]
 # Example: require external approval for GitHub API access.
-action = "allow"
+action = "delegate"
 pattern = "https://api.github.com/**"
 description = "GitHub API with external MFA"
 external_auth_profile = "github_mfa"
@@ -335,7 +335,7 @@ value = "{{reason}}"
 
 [[policy.rules]]
 # Example: use a sync plugin to allow a set of repository URLs.
-action = "allow"
+action = "delegate"
 pattern = "https://repo.internal/**"
 description = "Repo access via auth plugin"
 external_auth_profile = "url_allow"

--- a/docs/design/auth-plugins-design.md
+++ b/docs/design/auth-plugins-design.md
@@ -2,23 +2,23 @@
 
 ## Overview
 
-External auth profiles now support two modes:
+External auth profiles support two modes:
 
 - `http`: the existing async approval flow (webhook + callback).
-- `plugin`: a long-running stdio process that returns allow/deny with optional
+- `plugin`: a long-running stdio process that returns allow/deny/pass with optional
   request/response header actions.
 
-This keeps the existing `external_auth_profile` rule wiring intact while
+This keeps the existing `external_auth_profile` profile wiring intact while
 introducing a synchronous, per-request authorization plugin for cases like
 URL allowlists or repo ACLs.
 
 ## Goals
 
 - Preserve current async HTTP external auth behavior and configuration.
-- Add a sync, stdio-based plugin that returns allow/deny.
-- Reuse `policy.external_auth_profiles` and `external_auth_profile` in rules.
+- Add a sync, stdio-based plugin that returns allow/deny/pass.
+- Reuse `policy.external_auth_profiles` and `external_auth_profile` in delegate rules.
 - Support full header action outputs from plugins (request + response).
-- Keep the change minimal and backwards compatible.
+- Keep the protocol explicit: `pass` continues policy evaluation without header actions.
 
 ## Non-goals
 
@@ -76,16 +76,16 @@ restart_delay_ms = 10000
 
 ### Rule usage
 
-Rules continue to use `external_auth_profile` and `action = "allow"`:
+Rules use `action = "delegate"` with `external_auth_profile`:
 
 ```toml
 [[policy.rules]]
-action = "allow"
+action = "delegate"
 pattern = "https://repo.example.com/**"
 external_auth_profile = "url_allow"
 ```
 
-Rules must not set `external_auth_profile` on deny rules.
+Rules must not set `external_auth_profile` on `allow` or `deny` rules.
 
 ### Header action precedence
 
@@ -95,6 +95,10 @@ For allow decisions, apply header actions in this order:
 2. Plugin `requestHeaders` / `responseHeaders`
 
 This lets the plugin override or remove static defaults when needed.
+
+For pass decisions, do not apply rule or plugin header actions. A plugin response
+with `decision = "pass"` and non-empty `requestHeaders` or `responseHeaders` is
+a protocol error.
 
 ### Failure behavior
 
@@ -159,8 +163,11 @@ The plugin communicates via NDJSON (one JSON object per line).
 
 Notes:
 
+- `decision` is `"allow"`, `"deny"`, or `"pass"`.
 - `headers` may be empty or omitted when no headers are included.
 - Header values may be strings; repeated headers may be encoded as arrays.
+- `requestHeaders` and `responseHeaders` are valid only with `decision = "allow"`;
+  they must be empty or omitted with `decision = "pass"`.
 - Plugins should write only JSON responses to stdout.
 
 ## Runtime behavior
@@ -177,7 +184,7 @@ Log entries include:
 - Profile name
 - Request ID
 - URL, method, client IP
-- Decision (allow/deny)
+- Decision (allow/deny/pass)
 - Failure reason (when applicable)
 
 ## Demo
@@ -189,9 +196,9 @@ A reference plugin (`url_allow`) lives in `demos/auth-plugin-stdio`.
 Decisions captured in this revision:
 
 - Keep async HTTP external auth unchanged; add a sync stdio plugin mode only.
-- Reuse `external_auth_profiles` + `external_auth_profile` on allow rules.
+- Reuse `external_auth_profiles` + `external_auth_profile` on delegate rules.
 - Apply rule `header_actions` first, then plugin header actions (plugin can override).
-- Treat plugin failures as 503 errors (deny is only on explicit `decision = "deny"`).
+- Treat plugin failures as 503 errors (deny is only on explicit `decision = "deny"`; pass continues policy evaluation).
 
 Open questions and gaps:
 

--- a/docs/design/auth-plugins-design.md
+++ b/docs/design/auth-plugins-design.md
@@ -166,8 +166,9 @@ Notes:
 - `decision` is `"allow"`, `"deny"`, or `"pass"`.
 - `headers` may be empty or omitted when no headers are included.
 - Header values may be strings; repeated headers may be encoded as arrays.
-- `requestHeaders` and `responseHeaders` are valid only with `decision = "allow"`;
-  they must be empty or omitted with `decision = "pass"`.
+- `requestHeaders` and `responseHeaders` are applied with `decision = "allow"`;
+  they are ignored with `decision = "deny"` and must be empty or omitted with
+  `decision = "pass"`.
 - Plugins should write only JSON responses to stdout.
 
 ## Runtime behavior

--- a/src/auth_plugin.rs
+++ b/src/auth_plugin.rs
@@ -49,6 +49,7 @@ pub enum PluginDecision {
         header_actions: Vec<CompiledHeaderAction>,
     },
     Deny,
+    Pass,
 }
 
 #[derive(Clone)]
@@ -231,11 +232,12 @@ struct PluginResponse {
     response_headers: Vec<PluginHeaderAction>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Copy, Deserialize)]
 #[serde(rename_all = "lowercase")]
 enum PluginDecisionKind {
     Allow,
     Deny,
+    Pass,
 }
 
 #[derive(Debug, Deserialize)]
@@ -476,6 +478,21 @@ fn handle_plugin_response(
             );
             Ok(PluginDecision::Deny)
         }
+        PluginDecisionKind::Pass => {
+            tracing::debug!(
+                handler = %config.name,
+                request_id = %response.id,
+                decision = "pass",
+                "auth plugin decision"
+            );
+            if !response.request_headers.is_empty() || !response.response_headers.is_empty() {
+                Err(PluginError::new(
+                    "auth plugin pass decision must not include header actions",
+                ))
+            } else {
+                Ok(PluginDecision::Pass)
+            }
+        }
     };
 
     let _ = sender.send(result);
@@ -709,5 +726,59 @@ fn drain_pending(
 ) {
     for (_id, sender) in pending.drain() {
         let _ = sender.send(Err(PluginError::new(err.message())));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> AuthPluginConfig {
+        AuthPluginConfig {
+            name: "test_plugin".to_string(),
+            command: "unused".to_string(),
+            args: Vec::new(),
+            timeout: Duration::from_millis(1000),
+            include_headers: Vec::new(),
+            env: BTreeMap::new(),
+            restart_delay: Duration::from_millis(10),
+        }
+    }
+
+    fn parse_response(line: &str) -> Result<PluginDecision, PluginError> {
+        let config = test_config();
+        let (tx, mut rx) = oneshot::channel();
+        let mut pending = HashMap::new();
+        pending.insert("req-1".to_string(), tx);
+
+        handle_plugin_response(&config, line.to_string(), &mut pending);
+
+        rx.try_recv()
+            .expect("plugin response should resolve pending request")
+    }
+
+    #[test]
+    fn plugin_pass_without_header_actions_is_accepted() {
+        let decision = parse_response(
+            r#"{"id":"req-1","type":"response","decision":"pass"}"#,
+        )
+        .expect("pass should parse");
+
+        assert!(matches!(decision, PluginDecision::Pass));
+    }
+
+    #[test]
+    fn plugin_pass_with_request_header_actions_is_rejected() {
+        let err = parse_response(
+            r#"{"id":"req-1","type":"response","decision":"pass","requestHeaders":[{"action":"set","name":"x-test","value":"one"}]}"#,
+        )
+        .expect_err("pass with header actions should fail");
+
+        assert!(
+            err.message()
+                .contains("pass decision must not include header actions"),
+            "unexpected error: {}",
+            err.message()
+        );
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -217,8 +217,9 @@ fn print_policy_table(policy: &crate::policy::EffectivePolicy) {
 
     for rule in &policy.rules {
         let action = match rule.action {
-            crate::config::PolicyDefaultAction::Allow => "allow",
-            crate::config::PolicyDefaultAction::Deny => "deny",
+            crate::config::PolicyRuleAction::Allow => "allow",
+            crate::config::PolicyRuleAction::Deny => "deny",
+            crate::config::PolicyRuleAction::Delegate => "delegate",
         };
 
         let pattern = rule.pattern.as_deref().unwrap_or("-");

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -490,9 +490,17 @@ pub enum PolicyDefaultAction {
     Deny,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum PolicyRuleAction {
+    Allow,
+    Deny,
+    Delegate,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PolicyRuleTemplateConfig {
-    pub action: PolicyDefaultAction,
+    pub action: PolicyRuleAction,
 
     #[serde(default)]
     pub pattern: Option<String>,
@@ -559,7 +567,7 @@ pub struct PolicyRuleIncludeConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PolicyRuleDirectConfig {
-    pub action: PolicyDefaultAction,
+    pub action: PolicyRuleAction,
 
     #[serde(default)]
     pub pattern: Option<String>,
@@ -2524,7 +2532,7 @@ level = "info"
 default = "deny"
 
 [[policy.rules]]
-action = "allow"
+action = "delegate"
 pattern = "https://example.com/**"
 external_auth_profile = "missing_profile"
         "#;
@@ -2536,6 +2544,35 @@ external_auth_profile = "missing_profile"
             msg.contains("external_auth_profile 'missing_profile' not found"),
             "unexpected error: {msg}"
         );
+    }
+
+    #[test]
+    fn delegate_rule_with_external_auth_profile_is_valid() {
+        let toml = r#"
+schema_version = "1"
+
+[policy]
+default = "deny"
+
+[policy.external_auth_profiles.example]
+webhook_url = "https://auth.internal/start"
+timeout_ms = 1000
+
+[[policy.rules]]
+action = "delegate"
+pattern = "https://example.com/**"
+external_auth_profile = "example"
+        "#;
+
+        let config: Config = toml::from_str(toml).expect("parse config");
+        config
+            .validate_basic()
+            .expect("delegate rule should validate");
+        let rule = match &config.policy.rules[0] {
+            PolicyRuleConfig::Direct(rule) => rule,
+            PolicyRuleConfig::Include(_) => panic!("expected direct rule"),
+        };
+        assert!(matches!(rule.action, PolicyRuleAction::Delegate));
     }
 
     #[test]
@@ -2568,7 +2605,99 @@ external_auth_profile = "example"
         let err = config.validate_basic().expect_err("validation should fail");
         let msg = format!("{err}");
         assert!(
-            msg.contains("external_auth_profile is not allowed on deny rules"),
+            msg.contains("external_auth_profile is only allowed on delegate rules"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn external_auth_profile_not_allowed_on_allow_rule() {
+        let toml = r#"
+schema_version = "1"
+
+[policy]
+default = "deny"
+
+[policy.external_auth_profiles.example]
+webhook_url = "https://auth.internal/start"
+timeout_ms = 1000
+
+[[policy.rules]]
+action = "allow"
+pattern = "https://example.com/**"
+external_auth_profile = "example"
+        "#;
+
+        let config: Config = toml::from_str(toml).expect("parse config");
+        let err = config.validate_basic().expect_err("validation should fail");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("external_auth_profile is only allowed on delegate rules"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn delegate_rule_requires_external_auth_profile() {
+        let toml = r#"
+schema_version = "1"
+
+[policy]
+default = "deny"
+
+[[policy.rules]]
+action = "delegate"
+pattern = "https://example.com/**"
+        "#;
+
+        let config: Config = toml::from_str(toml).expect("parse config");
+        let err = config.validate_basic().expect_err("validation should fail");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("external_auth_profile is required on delegate rules"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn ruleset_delegate_template_requires_external_auth_profile() {
+        let toml = r#"
+schema_version = "1"
+
+[policy]
+default = "deny"
+
+[[policy.rules]]
+include = "delegated"
+
+[[policy.rulesets.delegated]]
+action = "delegate"
+pattern = "https://example.com/**"
+        "#;
+
+        let config: Config = toml::from_str(toml).expect("parse config");
+        let err = config.validate_basic().expect_err("validation should fail");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("external_auth_profile is required on delegate rules"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn policy_default_rejects_delegate() {
+        let toml = r#"
+schema_version = "1"
+
+[policy]
+default = "delegate"
+        "#;
+
+        let err =
+            ::toml::from_str::<Config>(toml).expect_err("parse should reject delegate default");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("delegate"),
             "unexpected error: {msg}"
         );
     }
@@ -2594,7 +2723,7 @@ type = "plugin"
 timeout_ms = 1000
 
 [[policy.rules]]
-action = "allow"
+action = "delegate"
 pattern = "https://example.com/**"
 external_auth_profile = "example"
         "#;
@@ -2645,7 +2774,7 @@ timeout_ms = 1000
 include_headers = ["authorization token"]
 
 [[policy.rules]]
-action = "allow"
+action = "delegate"
 pattern = "https://example.com/**"
 external_auth_profile = "example"
             "#,

--- a/src/external_auth.rs
+++ b/src/external_auth.rs
@@ -22,6 +22,7 @@ use crate::config::{
 pub enum ExternalDecision {
     Allow,
     Deny,
+    Pass,
 }
 
 /// Behavior to apply when the **initial** webhook fails.

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -12,7 +12,7 @@ use std::thread;
 use tracing::Level;
 use tracing_subscriber::fmt::SubscriberBuilder;
 
-use crate::config::{LoggingConfig, LoggingPolicyDecisionsConfig, PolicyDefaultAction};
+use crate::config::{LoggingConfig, LoggingPolicyDecisionsConfig, PolicyRuleAction};
 use crate::policy::PolicyDecision;
 
 const LOG_FILENAME: &str = "acl-proxy.log";
@@ -182,8 +182,9 @@ impl LoggingSettings {
         let (rule_action, rule_pattern, rule_description) = match ctx.decision.matched.as_ref() {
             Some(m) => {
                 let action = match m.action {
-                    PolicyDefaultAction::Allow => "allow",
-                    PolicyDefaultAction::Deny => "deny",
+                    PolicyRuleAction::Allow => "allow",
+                    PolicyRuleAction::Deny => "deny",
+                    PolicyRuleAction::Delegate => "delegate",
                 };
                 (Some(action), m.pattern.as_deref(), m.description.as_deref())
             }

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -12,9 +12,9 @@ use url::Url;
 use crate::config::{
     EgressRequestHeaderActionConfig, ExternalAuthProfileConfigMap, HeaderActionConfig,
     HeaderActionKind, HeaderDirection, HeaderMatchValueConfig, HeaderWhen, MacroMap,
-    MacroOverrideMap, MacroValues, PolicyConfig, PolicyDefaultAction, PolicyRuleConfig,
-    PolicyRuleDirectConfig, PolicyRuleIncludeConfig, PolicyRuleTemplateConfig, RulesetMap,
-    UrlEncVariants,
+    MacroOverrideMap, MacroValues, PolicyConfig, PolicyDefaultAction, PolicyRuleAction,
+    PolicyRuleConfig, PolicyRuleDirectConfig, PolicyRuleIncludeConfig, PolicyRuleTemplateConfig,
+    RulesetMap, UrlEncVariants,
 };
 
 #[derive(Debug, Error)]
@@ -51,7 +51,7 @@ pub struct PolicyDecision {
 #[derive(Debug, Clone)]
 pub struct MatchedRule {
     pub index: usize,
-    pub action: PolicyDefaultAction,
+    pub action: PolicyRuleAction,
     pub pattern: Option<String>,
     pub description: Option<String>,
     pub rule_id: Option<String>,
@@ -71,7 +71,7 @@ pub struct PolicyEngine {
 #[derive(Debug, Clone)]
 struct CompiledRule {
     index: usize,
-    action: PolicyDefaultAction,
+    action: PolicyRuleAction,
     pattern: Option<String>,
     regex: Option<Regex>,
     description: Option<String>,
@@ -99,7 +99,7 @@ struct ExpandedPolicy {
 
 #[derive(Debug, Clone)]
 struct ExpandedRule {
-    action: PolicyDefaultAction,
+    action: PolicyRuleAction,
     pattern: Option<String>,
     description: Option<String>,
     rule_id: Option<String>,
@@ -126,7 +126,7 @@ pub struct EffectivePolicy {
 #[derive(Debug, Clone, Serialize)]
 pub struct EffectiveRule {
     pub index: usize,
-    pub action: PolicyDefaultAction,
+    pub action: PolicyRuleAction,
     pub pattern: Option<String>,
     pub description: Option<String>,
     pub rule_id: Option<String>,
@@ -219,6 +219,17 @@ impl PolicyEngine {
         method: Option<&str>,
         headers: &HeaderMap<HeaderValue>,
     ) -> PolicyDecision {
+        self.evaluate_from(0, url_str, client_ip, method, headers)
+    }
+
+    pub fn evaluate_from(
+        &self,
+        start_index: usize,
+        url_str: &str,
+        client_ip: Option<&str>,
+        method: Option<&str>,
+        headers: &HeaderMap<HeaderValue>,
+    ) -> PolicyDecision {
         let normalized_url = match normalize_url(url_str) {
             Ok(u) => u,
             Err(_) => {
@@ -232,7 +243,7 @@ impl PolicyEngine {
         let normalized_ip = normalize_client_ip(client_ip);
         let method_upper = method.map(|m| m.to_ascii_uppercase());
 
-        for rule in &self.rules {
+        for rule in self.rules.iter().skip(start_index) {
             if let Some(ref re) = rule.regex {
                 if !re.is_match(&normalized_url) {
                     continue;
@@ -277,7 +288,7 @@ impl PolicyEngine {
                 external_auth_profile: rule.external_auth_profile.clone(),
             };
 
-            let allowed = matches!(rule.action, PolicyDefaultAction::Allow);
+            let allowed = matches!(rule.action, PolicyRuleAction::Allow);
 
             return PolicyDecision {
                 allowed,
@@ -422,22 +433,6 @@ fn expand_direct_rule(
         .map(|m| m.as_slice().to_vec())
         .unwrap_or_default();
 
-    if rule.external_auth_profile.is_some() && matches!(rule.action, PolicyDefaultAction::Deny) {
-        return Err(PolicyError::RuleInvalid {
-            index,
-            reason: "external_auth_profile is not allowed on deny rules".to_string(),
-        });
-    }
-
-    if let Some(name) = &rule.external_auth_profile {
-        if !external_profiles.contains_key(name) {
-            return Err(PolicyError::RuleInvalid {
-                index,
-                reason: format!("external_auth_profile '{}' not found", name),
-            });
-        }
-    }
-
     let has_pattern = patterns.is_some();
     let has_subnets = !rule.subnets.is_empty();
     let has_methods = !methods.is_empty();
@@ -445,6 +440,13 @@ fn expand_direct_rule(
     let has_headers_absent = headers_absent.is_some();
     let headers_match = validate_headers_match(rule.headers_match.as_ref(), index)?;
     let has_headers_match = headers_match.is_some();
+
+    validate_rule_external_auth(
+        rule.action,
+        rule.external_auth_profile.as_ref(),
+        external_profiles,
+        index,
+    )?;
 
     if !has_pattern && (has_subnets || has_methods || has_headers_absent || has_headers_match) {
         out.push(ExpandedRule {
@@ -543,6 +545,41 @@ fn expand_direct_rule(
     Ok(())
 }
 
+fn validate_rule_external_auth(
+    action: PolicyRuleAction,
+    external_auth_profile: Option<&String>,
+    external_profiles: &ExternalAuthProfileConfigMap,
+    index: usize,
+) -> Result<(), PolicyError> {
+    match action {
+        PolicyRuleAction::Delegate => {
+            let Some(name) = external_auth_profile else {
+                return Err(PolicyError::RuleInvalid {
+                    index,
+                    reason: "external_auth_profile is required on delegate rules".to_string(),
+                });
+            };
+
+            if !external_profiles.contains_key(name) {
+                return Err(PolicyError::RuleInvalid {
+                    index,
+                    reason: format!("external_auth_profile '{}' not found", name),
+                });
+            }
+        }
+        PolicyRuleAction::Allow | PolicyRuleAction::Deny => {
+            if external_auth_profile.is_some() {
+                return Err(PolicyError::RuleInvalid {
+                    index,
+                    reason: "external_auth_profile is only allowed on delegate rules".to_string(),
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
 fn normalize_patterns(
     pattern: Option<&String>,
     patterns: Option<&[String]>,
@@ -633,22 +670,12 @@ fn expand_include_rule(
         })?;
 
     for template in templates {
-        if template.external_auth_profile.is_some()
-            && matches!(template.action, PolicyDefaultAction::Deny)
-        {
-            return Err(PolicyError::RuleInvalid {
-                index,
-                reason: "external_auth_profile is not allowed on deny rules".to_string(),
-            });
-        }
-        if let Some(name) = &template.external_auth_profile {
-            if !external_profiles.contains_key(name) {
-                return Err(PolicyError::RuleInvalid {
-                    index,
-                    reason: format!("external_auth_profile '{}' not found", name),
-                });
-            }
-        }
+        validate_rule_external_auth(
+            template.action,
+            template.external_auth_profile.as_ref(),
+            external_profiles,
+            index,
+        )?;
     }
 
     let mut template_patterns = Vec::with_capacity(templates.len());
@@ -1411,8 +1438,8 @@ mod tests {
     use crate::config::{EgressRequestHeaderActionConfig, PolicyRuleTemplateConfig};
     use toml;
 
-    fn allow_action() -> PolicyDefaultAction {
-        PolicyDefaultAction::Allow
+    fn allow_action() -> PolicyRuleAction {
+        PolicyRuleAction::Allow
     }
 
     fn header_map(entries: &[(&str, &str)]) -> HeaderMap<HeaderValue> {
@@ -1518,7 +1545,7 @@ mod tests {
             rulesets: RulesetMap::default(),
             external_auth_profiles: ExternalAuthProfileConfigMap::default(),
             rules: vec![PolicyRuleConfig::Direct(PolicyRuleDirectConfig {
-                action: PolicyDefaultAction::Allow,
+                action: PolicyRuleAction::Allow,
                 pattern: None,
                 patterns: None,
                 description: None,
@@ -1549,7 +1576,7 @@ mod tests {
             rulesets: RulesetMap::default(),
             external_auth_profiles: ExternalAuthProfileConfigMap::default(),
             rules: vec![PolicyRuleConfig::Direct(PolicyRuleDirectConfig {
-                action: PolicyDefaultAction::Allow,
+                action: PolicyRuleAction::Allow,
                 pattern: None,
                 patterns: None,
                 description: None,
@@ -1712,7 +1739,7 @@ mod tests {
 default = "deny"
 
 [[rules]]
-action = "allow"
+	action = "allow"
 pattern = "https://example.com/**"
 methods = ["GET", "HEAD"]
         "#;
@@ -2324,7 +2351,7 @@ webhook_url = "https://auth.internal/start"
 timeout_ms = 5000
 
 [[rules]]
-action = "allow"
+action = "delegate"
 pattern = "https://example.com/**"
 headers_match = { "x-workload-id" = "worker-123" }
 external_auth_profile = "example"
@@ -2352,7 +2379,7 @@ pattern = "https://example.com/**"
             None
         );
 
-        assert!(hit.allowed);
+        assert!(!hit.allowed);
         assert_eq!(hit.matched.as_ref().map(|rule| rule.index), Some(0));
         assert_eq!(
             hit.matched
@@ -2363,12 +2390,74 @@ pattern = "https://example.com/**"
     }
 
     #[test]
+    fn evaluate_from_resumes_after_delegate_rule() {
+        let toml = r#"
+default = "deny"
+
+[external_auth_profiles.example]
+webhook_url = "https://auth.internal/start"
+timeout_ms = 5000
+
+[[rules]]
+action = "delegate"
+pattern = "https://example.com/**"
+external_auth_profile = "example"
+
+[[rules]]
+action = "allow"
+pattern = "https://example.com/public/**"
+        "#;
+
+        let cfg: PolicyConfig = toml::from_str(toml).expect("parse policy config");
+        let engine = PolicyEngine::from_config(&cfg).expect("build policy engine");
+        let headers = HeaderMap::new();
+
+        let first = engine.evaluate("https://example.com/public/index", None, Some("GET"), &headers);
+        assert!(!first.allowed);
+        assert_eq!(first.matched.as_ref().map(|rule| rule.index), Some(0));
+        assert!(matches!(
+            first.matched.as_ref().map(|rule| rule.action),
+            Some(PolicyRuleAction::Delegate)
+        ));
+
+        let resumed =
+            engine.evaluate_from(1, "https://example.com/public/index", None, Some("GET"), &headers);
+        assert!(resumed.allowed);
+        assert_eq!(resumed.matched.as_ref().map(|rule| rule.index), Some(1));
+    }
+
+    #[test]
+    fn evaluate_from_after_delegate_uses_default_when_no_later_match() {
+        let toml = r#"
+default = "deny"
+
+[external_auth_profiles.example]
+webhook_url = "https://auth.internal/start"
+timeout_ms = 5000
+
+[[rules]]
+action = "delegate"
+pattern = "https://example.com/**"
+external_auth_profile = "example"
+        "#;
+
+        let cfg: PolicyConfig = toml::from_str(toml).expect("parse policy config");
+        let engine = PolicyEngine::from_config(&cfg).expect("build policy engine");
+        let headers = HeaderMap::new();
+
+        let resumed =
+            engine.evaluate_from(1, "https://example.com/path", None, Some("GET"), &headers);
+        assert!(!resumed.allowed);
+        assert!(resumed.matched.is_none());
+    }
+
+    #[test]
     fn headers_match_only_rule_is_valid_match_criteria() {
         let toml = r#"
 default = "deny"
 
 [[rules]]
-action = "allow"
+	action = "allow"
 headers_match = { "x-workload-id" = "worker-123" }
         "#;
 
@@ -2456,7 +2545,7 @@ patterns = [
 ]
 
 [[rules]]
-action = "allow"
+	action = "allow"
 pattern = "https://example.com/**"
         "#;
 
@@ -2478,7 +2567,7 @@ webhook_url = "https://auth.internal/start"
 timeout_ms = 5000
 
 [[rules]]
-action = "allow"
+action = "delegate"
 patterns = [
   "https://example.com/api/**",
   "https://example.com/files/**",
@@ -2506,7 +2595,7 @@ value = "one"
             &headers,
         );
 
-        assert!(decision.allowed);
+        assert!(!decision.allowed);
         let matched = decision.matched.expect("matched rule");
         assert_eq!(
             matched.pattern.as_deref(),
@@ -2857,7 +2946,7 @@ webhook_url = "https://auth.internal/start"
 timeout_ms = 5000
 
 [[rules]]
-action = "allow"
+action = "delegate"
 pattern = "https://example.com/**"
 external_auth_profile = "example"
         "#;

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -2452,6 +2452,42 @@ external_auth_profile = "example"
     }
 
     #[test]
+    fn static_deny_before_delegate_is_terminal() {
+        let toml = r#"
+default = "allow"
+
+[external_auth_profiles.example]
+webhook_url = "https://auth.internal/start"
+timeout_ms = 5000
+
+[[rules]]
+action = "deny"
+pattern = "https://example.com/private/**"
+
+[[rules]]
+action = "delegate"
+pattern = "https://example.com/**"
+external_auth_profile = "example"
+        "#;
+
+        let cfg: PolicyConfig = toml::from_str(toml).expect("parse policy config");
+        let engine = PolicyEngine::from_config(&cfg).expect("build policy engine");
+        let headers = HeaderMap::new();
+
+        let decision = engine.evaluate(
+            "https://example.com/private/secret",
+            None,
+            Some("GET"),
+            &headers,
+        );
+
+        assert!(!decision.allowed);
+        let matched = decision.matched.expect("matched rule");
+        assert_eq!(matched.index, 0);
+        assert!(matches!(matched.action, PolicyRuleAction::Deny));
+    }
+
+    #[test]
     fn headers_match_only_rule_is_valid_match_criteria() {
         let toml = r#"
 default = "deny"

--- a/src/proxy/http.rs
+++ b/src/proxy/http.rs
@@ -29,6 +29,7 @@ use crate::capture::{
 };
 use crate::config::{
     EgressTargetConfig, ExternalAuthProfileType, HeaderActionKind, HeaderDirection, HeaderWhen,
+    PolicyRuleAction,
 };
 use crate::external_auth::{ApprovalMacroDescriptor, ExternalAuthProfile, ExternalDecision};
 use crate::logging::PolicyDecisionLogContext;
@@ -64,6 +65,11 @@ enum UpstreamRequestError {
     Hyper(#[from] hyper::Error),
     #[error(transparent)]
     Io(#[from] std::io::Error),
+}
+
+pub(crate) enum ExternalAuthGateResult {
+    Response(Response<Body>),
+    Pass(Request<Body>),
 }
 
 /// Run the HTTP/1.1 proxy listener using the configured bind address/port.
@@ -130,7 +136,7 @@ where
 async fn handle_http_request(
     state: Arc<AppState>,
     remote_addr: SocketAddr,
-    req: Request<Body>,
+    mut req: Request<Body>,
 ) -> Result<Response<Body>, Infallible> {
     // Special-case HTTPS CONNECT requests, which are handled via a dedicated
     // MITM path in `https_connect`.
@@ -186,132 +192,222 @@ async fn handle_http_request(
         return Ok(resp);
     }
 
-    let policy = &state.policy;
-    let decision = policy.evaluate(
-        &full_url,
-        Some(&client_ip_for_policy),
-        Some(method.as_str()),
-        req.headers(),
-    );
-
-    state.logging.log_policy_decision(PolicyDecisionLogContext {
-        request_id: &request_id,
-        url: &full_url,
-        method: Some(method.as_str()),
-        client_ip: Some(&client_ip_for_policy),
-        decision: &decision,
-    });
-
-    if !decision.allowed {
-        let resp = build_policy_denied_response(
-            &state,
-            &request_id,
+    let mut start_index = 0;
+    loop {
+        let decision = state.policy.evaluate_from(
+            start_index,
             &full_url,
-            &method,
-            &client_endpoint,
-            version,
+            Some(&client_ip_for_policy),
+            Some(method.as_str()),
             req.headers(),
-        )
-        .await;
-        return Ok(resp);
-    }
+        );
 
-    let matched_rule = decision.matched.as_ref();
-    let header_actions = matched_rule
-        .map(|m| m.header_actions.clone())
-        .unwrap_or_default();
-    let egress_request_header_actions = state.egress_request_header_actions.clone();
-    let request_timeout_ms = matched_rule.and_then(|m| m.request_timeout_ms);
+        if !matches!(
+            decision.matched.as_ref().map(|rule| rule.action),
+            Some(PolicyRuleAction::Delegate)
+        ) {
+            state.logging.log_policy_decision(PolicyDecisionLogContext {
+                request_id: &request_id,
+                url: &full_url,
+                method: Some(method.as_str()),
+                client_ip: Some(&client_ip_for_policy),
+                decision: &decision,
+            });
+        }
 
-    if let Some(rule) = matched_rule {
-        if let Some(profile_name) = rule.external_auth_profile.as_ref() {
-            let profile_cfg = state.config.policy.external_auth_profiles.get(profile_name);
-
-            match profile_cfg.map(|cfg| &cfg.profile_type) {
-                Some(ExternalAuthProfileType::Http) => {
-                    if let Some(profile) = state.external_auth.get_profile(profile_name) {
-                        let resp = handle_external_auth_gate(
-                            state.clone(),
-                            &request_id,
-                            &full_url,
-                            &method,
-                            &client_endpoint,
-                            target,
-                            version,
-                            req,
-                            &client_ip_for_policy,
-                            rule.index,
-                            rule.rule_id.clone(),
-                            &profile,
-                            profile_name,
-                            request_timeout_ms,
-                            header_actions,
-                            egress_request_header_actions.clone(),
-                        )
-                        .await;
-                        return Ok(resp);
-                    }
-                }
-                Some(ExternalAuthProfileType::Plugin) => {
-                    if let Some(handler) = state.auth_plugins.get_handler(profile_name) {
-                        let resp = handle_auth_plugin_gate(
-                            state.clone(),
-                            &request_id,
-                            &full_url,
-                            &method,
-                            &client_endpoint,
-                            target,
-                            version,
-                            req,
-                            &client_ip_for_policy,
-                            profile_name,
-                            &handler,
-                            request_timeout_ms,
-                            header_actions,
-                            egress_request_header_actions.clone(),
-                        )
-                        .await;
-                        return Ok(resp);
-                    }
-                }
-                None => {}
+        let Some(rule) = decision.matched.as_ref() else {
+            if decision.allowed {
+                let response = proxy_allowed_request(
+                    state.clone(),
+                    request_id,
+                    full_url,
+                    method,
+                    version,
+                    client_endpoint,
+                    target,
+                    req,
+                    CaptureMode::HttpProxy,
+                    None,
+                    Vec::new(),
+                    state.egress_request_header_actions.clone(),
+                )
+                .await;
+                return Ok(response);
             }
 
-            let resp = build_external_auth_error_response(
+            let resp = build_policy_denied_response(
                 &state,
                 &request_id,
                 &full_url,
                 &method,
                 &client_endpoint,
-                target,
                 version,
                 req.headers(),
-                CaptureMode::HttpProxy,
-                "ExternalApprovalError",
-                "External auth profile not found",
             )
             .await;
             return Ok(resp);
+        };
+
+        match rule.action {
+            PolicyRuleAction::Deny => {
+                let resp = build_policy_denied_response(
+                    &state,
+                    &request_id,
+                    &full_url,
+                    &method,
+                    &client_endpoint,
+                    version,
+                    req.headers(),
+                )
+                .await;
+                return Ok(resp);
+            }
+            PolicyRuleAction::Allow => {
+                let response = proxy_allowed_request(
+                    state.clone(),
+                    request_id,
+                    full_url,
+                    method,
+                    version,
+                    client_endpoint,
+                    target,
+                    req,
+                    CaptureMode::HttpProxy,
+                    rule.request_timeout_ms,
+                    rule.header_actions.clone(),
+                    state.egress_request_header_actions.clone(),
+                )
+                .await;
+                return Ok(response);
+            }
+            PolicyRuleAction::Delegate => {
+                let Some(profile_name) = rule.external_auth_profile.as_ref() else {
+                    let resp = build_external_auth_error_response(
+                        &state,
+                        &request_id,
+                        &full_url,
+                        &method,
+                        &client_endpoint,
+                        target,
+                        version,
+                        req.headers(),
+                        CaptureMode::HttpProxy,
+                        "ExternalApprovalError",
+                        "External auth profile not found",
+                    )
+                    .await;
+                    return Ok(resp);
+                };
+
+                let profile_cfg = state.config.policy.external_auth_profiles.get(profile_name);
+                let gate_result = match profile_cfg.map(|cfg| &cfg.profile_type) {
+                    Some(ExternalAuthProfileType::Http) => {
+                        if let Some(profile) = state.external_auth.get_profile(profile_name) {
+                            run_external_auth_gate_lifecycle(
+                                state.clone(),
+                                &request_id,
+                                &full_url,
+                                &method,
+                                &client_endpoint,
+                                target.clone(),
+                                version,
+                                req,
+                                &client_ip_for_policy,
+                                rule.index,
+                                rule.rule_id.clone(),
+                                &profile,
+                                profile_name,
+                                rule.request_timeout_ms,
+                                rule.header_actions.clone(),
+                                state.egress_request_header_actions.clone(),
+                                CaptureMode::HttpProxy,
+                            )
+                            .await
+                        } else {
+                            let resp = build_external_auth_error_response(
+                                &state,
+                                &request_id,
+                                &full_url,
+                                &method,
+                                &client_endpoint,
+                                target,
+                                version,
+                                req.headers(),
+                                CaptureMode::HttpProxy,
+                                "ExternalApprovalError",
+                                "External auth profile not found",
+                            )
+                            .await;
+                            return Ok(resp);
+                        }
+                    }
+                    Some(ExternalAuthProfileType::Plugin) => {
+                        if let Some(handler) = state.auth_plugins.get_handler(profile_name) {
+                            run_auth_plugin_gate_lifecycle(
+                                state.clone(),
+                                &request_id,
+                                &full_url,
+                                &method,
+                                &client_endpoint,
+                                target.clone(),
+                                version,
+                                req,
+                                &client_ip_for_policy,
+                                profile_name,
+                                &handler,
+                                rule.request_timeout_ms,
+                                rule.header_actions.clone(),
+                                state.egress_request_header_actions.clone(),
+                                CaptureMode::HttpProxy,
+                            )
+                            .await
+                        } else {
+                            let resp = build_external_auth_error_response(
+                                &state,
+                                &request_id,
+                                &full_url,
+                                &method,
+                                &client_endpoint,
+                                target,
+                                version,
+                                req.headers(),
+                                CaptureMode::HttpProxy,
+                                "ExternalApprovalError",
+                                "External auth profile not found",
+                            )
+                            .await;
+                            return Ok(resp);
+                        }
+                    }
+                    None => {
+                        let resp = build_external_auth_error_response(
+                            &state,
+                            &request_id,
+                            &full_url,
+                            &method,
+                            &client_endpoint,
+                            target,
+                            version,
+                            req.headers(),
+                            CaptureMode::HttpProxy,
+                            "ExternalApprovalError",
+                            "External auth profile not found",
+                        )
+                        .await;
+                        return Ok(resp);
+                    }
+                };
+
+                match gate_result {
+                    ExternalAuthGateResult::Response(resp) => return Ok(resp),
+                    ExternalAuthGateResult::Pass(original_req) => {
+                        req = original_req;
+                        start_index = rule.index + 1;
+                    }
+                }
+            }
         }
     }
-
-    let response = proxy_allowed_request(
-        state.clone(),
-        request_id,
-        full_url,
-        method,
-        version,
-        client_endpoint,
-        target,
-        req,
-        CaptureMode::HttpProxy,
-        request_timeout_ms,
-        header_actions,
-        egress_request_header_actions,
-    )
-    .await;
-
-    Ok(response)
 }
 
 fn is_internal_endpoint(uri: &Uri, base: &str, suffix: &str) -> bool {
@@ -377,11 +473,12 @@ struct ExternalAuthCallbackBody {
     macros: Option<BTreeMap<String, String>>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Copy, Deserialize)]
 #[serde(rename_all = "lowercase")]
 enum ExternalAuthCallbackDecision {
     Allow,
     Deny,
+    Pass,
 }
 
 async fn handle_external_auth_callback_request(
@@ -584,6 +681,7 @@ async fn handle_external_auth_callback_request(
     let decision = match payload.decision {
         ExternalAuthCallbackDecision::Allow => ExternalDecision::Allow,
         ExternalAuthCallbackDecision::Deny => ExternalDecision::Deny,
+        ExternalAuthCallbackDecision::Pass => ExternalDecision::Pass,
     };
 
     let found = state.external_auth.resolve(&payload.request_id, decision);
@@ -632,7 +730,7 @@ pub(crate) async fn run_external_auth_gate_lifecycle(
     header_actions: Vec<CompiledHeaderAction>,
     egress_request_header_actions: Vec<CompiledHeaderAction>,
     mode: CaptureMode,
-) -> Response<Body> {
+) -> ExternalAuthGateResult {
     let macro_descriptors =
         discover_approval_macros(&state.config.policy.approval_macros, &header_actions);
 
@@ -656,7 +754,7 @@ pub(crate) async fn run_external_auth_gate_lifecycle(
 
         drop(guard);
 
-        return match profile.on_webhook_failure {
+        return ExternalAuthGateResult::Response(match profile.on_webhook_failure {
             crate::external_auth::WebhookFailureMode::Deny => {
                 build_external_auth_denied_response(
                     &state,
@@ -701,13 +799,21 @@ pub(crate) async fn run_external_auth_gate_lifecycle(
                 )
                 .await
             }
-        };
+        });
     }
 
     let decision = tokio::time::timeout(profile.timeout, decision_rx).await;
 
     match decision {
         Ok(Ok(ExternalDecision::Allow)) => {
+            tracing::info!(
+                request_id = %request_id,
+                action = "delegate",
+                external_decision = "allow",
+                final_outcome = "allow",
+                rule_index,
+                "delegate policy decision"
+            );
             let macro_values = state.external_auth.take_macro_values(request_id);
             let header_actions = match interpolate_header_actions(header_actions, &macro_values) {
                 Ok(actions) => actions,
@@ -716,7 +822,7 @@ pub(crate) async fn run_external_auth_gate_lifecycle(
                         .external_auth
                         .finalize_internal_error(request_id, &msg);
                     drop(guard);
-                    return build_external_auth_error_response(
+                    return ExternalAuthGateResult::Response(build_external_auth_error_response(
                         &state,
                         request_id,
                         url,
@@ -729,11 +835,11 @@ pub(crate) async fn run_external_auth_gate_lifecycle(
                         "ExternalApprovalError",
                         "External approval macro interpolation failed",
                     )
-                    .await;
+                    .await);
                 }
             };
             drop(guard);
-            proxy_allowed_request(
+            ExternalAuthGateResult::Response(proxy_allowed_request(
                 state.clone(),
                 request_id.to_string(),
                 url.to_string(),
@@ -747,11 +853,19 @@ pub(crate) async fn run_external_auth_gate_lifecycle(
                 header_actions,
                 egress_request_header_actions,
             )
-            .await
+            .await)
         }
         Ok(Ok(ExternalDecision::Deny)) => {
+            tracing::info!(
+                request_id = %request_id,
+                action = "delegate",
+                external_decision = "deny",
+                final_outcome = "deny",
+                rule_index,
+                "delegate policy decision"
+            );
             drop(guard);
-            build_external_auth_denied_response(
+            ExternalAuthGateResult::Response(build_external_auth_denied_response(
                 &state,
                 request_id,
                 url,
@@ -762,14 +876,26 @@ pub(crate) async fn run_external_auth_gate_lifecycle(
                 req.headers(),
                 mode,
             )
-            .await
+            .await)
+        }
+        Ok(Ok(ExternalDecision::Pass)) => {
+            tracing::info!(
+                request_id = %request_id,
+                action = "delegate",
+                external_decision = "pass",
+                final_outcome = "continued",
+                rule_index,
+                "delegate policy decision"
+            );
+            drop(guard);
+            ExternalAuthGateResult::Pass(req)
         }
         Ok(Err(_recv_closed)) => {
             state
                 .external_auth
                 .finalize_internal_error(request_id, "External approval channel closed");
             drop(guard);
-            build_external_auth_error_response(
+            ExternalAuthGateResult::Response(build_external_auth_error_response(
                 &state,
                 request_id,
                 url,
@@ -782,12 +908,12 @@ pub(crate) async fn run_external_auth_gate_lifecycle(
                 "ExternalApprovalError",
                 "External approval channel closed",
             )
-            .await
+            .await)
         }
         Err(_elapsed) => {
             state.external_auth.finalize_timed_out(request_id);
             drop(guard);
-            build_external_auth_timeout_response(
+            ExternalAuthGateResult::Response(build_external_auth_timeout_response(
                 &state,
                 request_id,
                 url,
@@ -798,85 +924,9 @@ pub(crate) async fn run_external_auth_gate_lifecycle(
                 req.headers(),
                 mode,
             )
-            .await
+            .await)
         }
     }
-}
-
-async fn handle_external_auth_gate(
-    state: Arc<AppState>,
-    request_id: &str,
-    url: &str,
-    method: &Method,
-    client: &CaptureEndpoint,
-    target: Option<CaptureEndpoint>,
-    version: Version,
-    req: Request<Body>,
-    client_ip_for_policy: &str,
-    rule_index: usize,
-    rule_id: Option<String>,
-    profile: &ExternalAuthProfile,
-    profile_name: &str,
-    request_timeout_ms: Option<u64>,
-    header_actions: Vec<CompiledHeaderAction>,
-    egress_request_header_actions: Vec<CompiledHeaderAction>,
-) -> Response<Body> {
-    run_external_auth_gate_lifecycle(
-        state,
-        request_id,
-        url,
-        method,
-        client,
-        target,
-        version,
-        req,
-        client_ip_for_policy,
-        rule_index,
-        rule_id,
-        profile,
-        profile_name,
-        request_timeout_ms,
-        header_actions,
-        egress_request_header_actions,
-        CaptureMode::HttpProxy,
-    )
-    .await
-}
-
-async fn handle_auth_plugin_gate(
-    state: Arc<AppState>,
-    request_id: &str,
-    url: &str,
-    method: &Method,
-    client: &CaptureEndpoint,
-    target: Option<CaptureEndpoint>,
-    version: Version,
-    req: Request<Body>,
-    client_ip_for_policy: &str,
-    profile_name: &str,
-    handler: &AuthPluginHandle,
-    request_timeout_ms: Option<u64>,
-    header_actions: Vec<CompiledHeaderAction>,
-    egress_request_header_actions: Vec<CompiledHeaderAction>,
-) -> Response<Body> {
-    run_auth_plugin_gate_lifecycle(
-        state,
-        request_id,
-        url,
-        method,
-        client,
-        target,
-        version,
-        req,
-        client_ip_for_policy,
-        profile_name,
-        handler,
-        request_timeout_ms,
-        header_actions,
-        egress_request_header_actions,
-        CaptureMode::HttpProxy,
-    )
-    .await
 }
 
 pub(crate) async fn run_auth_plugin_gate_lifecycle(
@@ -895,7 +945,7 @@ pub(crate) async fn run_auth_plugin_gate_lifecycle(
     header_actions: Vec<CompiledHeaderAction>,
     egress_request_header_actions: Vec<CompiledHeaderAction>,
     mode: CaptureMode,
-) -> Response<Body> {
+) -> ExternalAuthGateResult {
     let decision = handler
         .evaluate(request_id, url, method, client_ip_for_policy, req.headers())
         .await;
@@ -904,9 +954,16 @@ pub(crate) async fn run_auth_plugin_gate_lifecycle(
         Ok(PluginDecision::Allow {
             header_actions: plugin_actions,
         }) => {
+            tracing::info!(
+                request_id = %request_id,
+                action = "delegate",
+                external_decision = "allow",
+                final_outcome = "allow",
+                "delegate policy decision"
+            );
             let mut combined = header_actions;
             combined.extend(plugin_actions);
-            proxy_allowed_request(
+            ExternalAuthGateResult::Response(proxy_allowed_request(
                 state.clone(),
                 request_id.to_string(),
                 url.to_string(),
@@ -920,10 +977,17 @@ pub(crate) async fn run_auth_plugin_gate_lifecycle(
                 combined,
                 egress_request_header_actions,
             )
-            .await
+            .await)
         }
         Ok(PluginDecision::Deny) => {
-            build_auth_plugin_denied_response(
+            tracing::info!(
+                request_id = %request_id,
+                action = "delegate",
+                external_decision = "deny",
+                final_outcome = "deny",
+                "delegate policy decision"
+            );
+            ExternalAuthGateResult::Response(build_auth_plugin_denied_response(
                 &state,
                 request_id,
                 url,
@@ -934,11 +998,21 @@ pub(crate) async fn run_auth_plugin_gate_lifecycle(
                 req.headers(),
                 mode,
             )
-            .await
+            .await)
+        }
+        Ok(PluginDecision::Pass) => {
+            tracing::info!(
+                request_id = %request_id,
+                action = "delegate",
+                external_decision = "pass",
+                final_outcome = "continued",
+                "delegate policy decision"
+            );
+            ExternalAuthGateResult::Pass(req)
         }
         Err(err) => {
             let message = format!("Auth plugin '{}' failed: {}", profile_name, err.message());
-            build_auth_plugin_error_response(
+            ExternalAuthGateResult::Response(build_auth_plugin_error_response(
                 &state,
                 request_id,
                 url,
@@ -950,7 +1024,7 @@ pub(crate) async fn run_auth_plugin_gate_lifecycle(
                 mode,
                 &message,
             )
-            .await
+            .await)
         }
     }
 }

--- a/src/proxy/https_connect.rs
+++ b/src/proxy/https_connect.rs
@@ -13,12 +13,12 @@ use tokio_rustls::TlsAcceptor;
 
 use crate::app::AppState;
 use crate::capture::{CaptureDecision, CaptureEndpoint, CaptureMode};
-use crate::config::ExternalAuthProfileType;
+use crate::config::{ExternalAuthProfileType, PolicyRuleAction};
 use crate::logging::PolicyDecisionLogContext;
 use crate::proxy::http::{
     build_external_auth_error_response, build_loop_detected_response, generate_request_id,
     has_loop_header, proxy_allowed_request, run_auth_plugin_gate_lifecycle,
-    run_external_auth_gate_lifecycle,
+    run_external_auth_gate_lifecycle, ExternalAuthGateResult,
 };
 
 /// Handle an incoming CONNECT request on the HTTP listener.
@@ -218,7 +218,7 @@ async fn handle_inner_https_request(
     client: CaptureEndpoint,
     target: CaptureEndpoint,
     client_ip_for_policy: String,
-    req: Request<Body>,
+    mut req: Request<Body>,
 ) -> Result<Response<Body>, hyper::Error> {
     let request_id = generate_request_id();
     let method = req.method().clone();
@@ -245,173 +245,224 @@ async fn handle_inner_https_request(
         return Ok(resp);
     }
 
-    let decision = state.policy.evaluate(
-        &full_url,
-        Some(&client_ip_for_policy),
-        Some(method.as_str()),
-        req.headers(),
-    );
-
-    state.logging.log_policy_decision(PolicyDecisionLogContext {
-        request_id: &request_id,
-        url: &full_url,
-        method: Some(method.as_str()),
-        client_ip: Some(&client_ip_for_policy),
-        decision: &decision,
-    });
-
-    if !decision.allowed {
-        let resp = build_connect_policy_denied_response(
-            &state,
-            &request_id,
+    let mut start_index = 0;
+    loop {
+        let decision = state.policy.evaluate_from(
+            start_index,
             &full_url,
-            &method,
-            &client,
-            target,
-            version,
+            Some(&client_ip_for_policy),
+            Some(method.as_str()),
             req.headers(),
-        )
-        .await;
-        return Ok(resp);
-    }
+        );
 
-    let matched_rule = decision.matched.as_ref();
-    let header_actions = matched_rule
-        .map(|m| m.header_actions.clone())
-        .unwrap_or_default();
-    let egress_request_header_actions = state.egress_request_header_actions.clone();
-    let request_timeout_ms = matched_rule.and_then(|m| m.request_timeout_ms);
+        if !matches!(
+            decision.matched.as_ref().map(|rule| rule.action),
+            Some(PolicyRuleAction::Delegate)
+        ) {
+            state.logging.log_policy_decision(PolicyDecisionLogContext {
+                request_id: &request_id,
+                url: &full_url,
+                method: Some(method.as_str()),
+                client_ip: Some(&client_ip_for_policy),
+                decision: &decision,
+            });
+        }
 
-    if let Some(rule) = matched_rule {
-        if let Some(profile_name) = rule.external_auth_profile.as_ref() {
-            let profile_cfg = state.config.policy.external_auth_profiles.get(profile_name);
+        let Some(rule) = decision.matched.as_ref() else {
+            if decision.allowed {
+                let resp = proxy_allowed_request(
+                    state.clone(),
+                    request_id,
+                    full_url,
+                    method,
+                    version,
+                    client,
+                    Some(target),
+                    req,
+                    CaptureMode::HttpsConnect,
+                    None,
+                    Vec::new(),
+                    state.egress_request_header_actions.clone(),
+                )
+                .await;
+                return Ok(resp);
+            }
 
-            match profile_cfg.map(|cfg| &cfg.profile_type) {
-                Some(ExternalAuthProfileType::Http) => {
-                    if let Some(profile) = state.external_auth.get_profile(profile_name) {
-                        let resp = handle_inner_external_auth_gate(
-                            state.clone(),
-                            &request_id,
-                            &full_url,
-                            &method,
-                            &client,
-                            target,
-                            version,
-                            req,
-                            &client_ip_for_policy,
-                            rule.index,
-                            rule.rule_id.clone(),
-                            &profile,
-                            profile_name,
-                            request_timeout_ms,
-                            header_actions,
-                            egress_request_header_actions.clone(),
-                        )
-                        .await;
-                        return Ok(resp);
+            let resp = build_connect_policy_denied_response(
+                &state,
+                &request_id,
+                &full_url,
+                &method,
+                &client,
+                target,
+                version,
+                req.headers(),
+            )
+            .await;
+            return Ok(resp);
+        };
+
+        match rule.action {
+            PolicyRuleAction::Deny => {
+                let resp = build_connect_policy_denied_response(
+                    &state,
+                    &request_id,
+                    &full_url,
+                    &method,
+                    &client,
+                    target,
+                    version,
+                    req.headers(),
+                )
+                .await;
+                return Ok(resp);
+            }
+            PolicyRuleAction::Allow => {
+                let resp = proxy_allowed_request(
+                    state.clone(),
+                    request_id,
+                    full_url,
+                    method,
+                    version,
+                    client,
+                    Some(target),
+                    req,
+                    CaptureMode::HttpsConnect,
+                    rule.request_timeout_ms,
+                    rule.header_actions.clone(),
+                    state.egress_request_header_actions.clone(),
+                )
+                .await;
+                return Ok(resp);
+            }
+            PolicyRuleAction::Delegate => {
+                let Some(profile_name) = rule.external_auth_profile.as_ref() else {
+                    let resp = build_external_auth_error_response(
+                        &state,
+                        &request_id,
+                        &full_url,
+                        &method,
+                        &client,
+                        Some(target),
+                        version,
+                        req.headers(),
+                        CaptureMode::HttpsConnect,
+                        "ExternalApprovalError",
+                        "External auth profile not found",
+                    )
+                    .await;
+                    return Ok(resp);
+                };
+
+                let profile_cfg = state.config.policy.external_auth_profiles.get(profile_name);
+                let gate_result = match profile_cfg.map(|cfg| &cfg.profile_type) {
+                    Some(ExternalAuthProfileType::Http) => {
+                        if let Some(profile) = state.external_auth.get_profile(profile_name) {
+                            run_external_auth_gate_lifecycle(
+                                state.clone(),
+                                &request_id,
+                                &full_url,
+                                &method,
+                                &client,
+                                Some(target.clone()),
+                                version,
+                                req,
+                                &client_ip_for_policy,
+                                rule.index,
+                                rule.rule_id.clone(),
+                                &profile,
+                                profile_name,
+                                rule.request_timeout_ms,
+                                rule.header_actions.clone(),
+                                state.egress_request_header_actions.clone(),
+                                CaptureMode::HttpsConnect,
+                            )
+                            .await
+                        } else {
+                            let resp = build_external_auth_error_response(
+                                &state,
+                                &request_id,
+                                &full_url,
+                                &method,
+                                &client,
+                                Some(target),
+                                version,
+                                req.headers(),
+                                CaptureMode::HttpsConnect,
+                                "ExternalApprovalError",
+                                "External auth profile not found",
+                            )
+                            .await;
+                            return Ok(resp);
+                        }
                     }
-                }
-                Some(ExternalAuthProfileType::Plugin) => {
-                    if let Some(handler) = state.auth_plugins.get_handler(profile_name) {
-                        let resp = run_auth_plugin_gate_lifecycle(
-                            state.clone(),
+                    Some(ExternalAuthProfileType::Plugin) => {
+                        if let Some(handler) = state.auth_plugins.get_handler(profile_name) {
+                            run_auth_plugin_gate_lifecycle(
+                                state.clone(),
+                                &request_id,
+                                &full_url,
+                                &method,
+                                &client,
+                                Some(target.clone()),
+                                version,
+                                req,
+                                &client_ip_for_policy,
+                                profile_name,
+                                &handler,
+                                rule.request_timeout_ms,
+                                rule.header_actions.clone(),
+                                state.egress_request_header_actions.clone(),
+                                CaptureMode::HttpsConnect,
+                            )
+                            .await
+                        } else {
+                            let resp = build_external_auth_error_response(
+                                &state,
+                                &request_id,
+                                &full_url,
+                                &method,
+                                &client,
+                                Some(target),
+                                version,
+                                req.headers(),
+                                CaptureMode::HttpsConnect,
+                                "ExternalApprovalError",
+                                "External auth profile not found",
+                            )
+                            .await;
+                            return Ok(resp);
+                        }
+                    }
+                    None => {
+                        let resp = build_external_auth_error_response(
+                            &state,
                             &request_id,
                             &full_url,
                             &method,
                             &client,
                             Some(target),
                             version,
-                            req,
-                            &client_ip_for_policy,
-                            profile_name,
-                            &handler,
-                            request_timeout_ms,
-                            header_actions,
-                            egress_request_header_actions.clone(),
+                            req.headers(),
                             CaptureMode::HttpsConnect,
+                            "ExternalApprovalError",
+                            "External auth profile not found",
                         )
                         .await;
                         return Ok(resp);
                     }
-                }
-                None => {}
-            }
+                };
 
-            let resp = build_external_auth_error_response(
-                &state,
-                &request_id,
-                &full_url,
-                &method,
-                &client,
-                Some(target),
-                version,
-                req.headers(),
-                CaptureMode::HttpsConnect,
-                "ExternalApprovalError",
-                "External auth profile not found",
-            )
-            .await;
-            return Ok(resp);
+                match gate_result {
+                    ExternalAuthGateResult::Response(resp) => return Ok(resp),
+                    ExternalAuthGateResult::Pass(original_req) => {
+                        req = original_req;
+                        start_index = rule.index + 1;
+                    }
+                }
+            }
         }
     }
-
-    let resp = proxy_allowed_request(
-        state.clone(),
-        request_id,
-        full_url,
-        method,
-        version,
-        client,
-        Some(target),
-        req,
-        CaptureMode::HttpsConnect,
-        request_timeout_ms,
-        header_actions,
-        egress_request_header_actions,
-    )
-    .await;
-
-    Ok(resp)
-}
-
-async fn handle_inner_external_auth_gate(
-    state: Arc<AppState>,
-    request_id: &str,
-    url: &str,
-    method: &Method,
-    client: &CaptureEndpoint,
-    target: CaptureEndpoint,
-    version: Version,
-    req: Request<Body>,
-    client_ip_for_policy: &str,
-    rule_index: usize,
-    rule_id: Option<String>,
-    profile: &crate::external_auth::ExternalAuthProfile,
-    profile_name: &str,
-    request_timeout_ms: Option<u64>,
-    header_actions: Vec<crate::policy::CompiledHeaderAction>,
-    egress_request_header_actions: Vec<crate::policy::CompiledHeaderAction>,
-) -> Response<Body> {
-    run_external_auth_gate_lifecycle(
-        state,
-        request_id,
-        url,
-        method,
-        client,
-        Some(target),
-        version,
-        req,
-        client_ip_for_policy,
-        rule_index,
-        rule_id,
-        profile,
-        profile_name,
-        request_timeout_ms,
-        header_actions,
-        egress_request_header_actions,
-        CaptureMode::HttpsConnect,
-    )
-    .await
 }
 
 fn build_https_url_for_inner_request(target: &CaptureEndpoint, uri: &Uri) -> String {

--- a/src/proxy/https_transparent.rs
+++ b/src/proxy/https_transparent.rs
@@ -14,12 +14,13 @@ use tokio_rustls::TlsAcceptor;
 
 use crate::app::{AppState, SharedAppState};
 use crate::capture::{CaptureEndpoint, CaptureMode};
-use crate::config::ExternalAuthProfileType;
+use crate::config::{ExternalAuthProfileType, PolicyRuleAction};
 use crate::logging::PolicyDecisionLogContext;
 use crate::proxy::http::{
     build_external_auth_error_response, build_loop_detected_response,
     build_policy_denied_response_with_mode, generate_request_id, has_loop_header,
     proxy_allowed_request, run_auth_plugin_gate_lifecycle, run_external_auth_gate_lifecycle,
+    ExternalAuthGateResult,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -221,7 +222,7 @@ async fn handle_inner_https_request(
     state: Arc<AppState>,
     client: CaptureEndpoint,
     client_ip_for_policy: String,
-    req: Request<Body>,
+    mut req: Request<Body>,
 ) -> Result<Response<Body>, hyper::Error> {
     let request_id = generate_request_id();
     let method = req.method().clone();
@@ -250,59 +251,146 @@ async fn handle_inner_https_request(
         return Ok(resp);
     }
 
-    let decision = state.policy.evaluate(
-        &full_url,
-        Some(&client_ip_for_policy),
-        Some(method.as_str()),
-        req.headers(),
-    );
-
-    state.logging.log_policy_decision(PolicyDecisionLogContext {
-        request_id: &request_id,
-        url: &full_url,
-        method: Some(method.as_str()),
-        client_ip: Some(&client_ip_for_policy),
-        decision: &decision,
-    });
-
-    if !decision.allowed {
-        let resp = build_policy_denied_response_with_mode(
-            &state,
-            &request_id,
+    let mut start_index = 0;
+    loop {
+        let decision = state.policy.evaluate_from(
+            start_index,
             &full_url,
-            &method,
-            &client,
-            target.clone(),
-            version,
+            Some(&client_ip_for_policy),
+            Some(method.as_str()),
             req.headers(),
-            CaptureMode::HttpsTransparent,
-        )
-        .await;
-        return Ok(resp);
-    }
+        );
 
-    let matched_rule = decision.matched.as_ref();
-    let header_actions = matched_rule
-        .map(|m| m.header_actions.clone())
-        .unwrap_or_default();
-    let egress_request_header_actions = state.egress_request_header_actions.clone();
-    let request_timeout_ms = matched_rule.and_then(|m| m.request_timeout_ms);
+        if !matches!(
+            decision.matched.as_ref().map(|rule| rule.action),
+            Some(PolicyRuleAction::Delegate)
+        ) {
+            state.logging.log_policy_decision(PolicyDecisionLogContext {
+                request_id: &request_id,
+                url: &full_url,
+                method: Some(method.as_str()),
+                client_ip: Some(&client_ip_for_policy),
+                decision: &decision,
+            });
+        }
 
-    if let Some(rule) = matched_rule {
-        if let Some(profile_name) = rule.external_auth_profile.as_ref() {
-            let profile_cfg = state.config.policy.external_auth_profiles.get(profile_name);
+        let Some(rule) = decision.matched.as_ref() else {
+            if decision.allowed {
+                let resp = proxy_allowed_request(
+                    state.clone(),
+                    request_id,
+                    full_url,
+                    method,
+                    version,
+                    client,
+                    target,
+                    req,
+                    CaptureMode::HttpsTransparent,
+                    None,
+                    Vec::new(),
+                    state.egress_request_header_actions.clone(),
+                )
+                .await;
+                return Ok(resp);
+            }
 
-            match profile_cfg.map(|cfg| &cfg.profile_type) {
-                Some(ExternalAuthProfileType::Http) => {
-                    if let Some(profile) = state.external_auth.get_profile(profile_name) {
-                        if let Some(target_endpoint) = target.clone() {
-                            let resp = handle_https_transparent_external_auth_gate(
+            let resp = build_policy_denied_response_with_mode(
+                &state,
+                &request_id,
+                &full_url,
+                &method,
+                &client,
+                target.clone(),
+                version,
+                req.headers(),
+                CaptureMode::HttpsTransparent,
+            )
+            .await;
+            return Ok(resp);
+        };
+
+        match rule.action {
+            PolicyRuleAction::Deny => {
+                let resp = build_policy_denied_response_with_mode(
+                    &state,
+                    &request_id,
+                    &full_url,
+                    &method,
+                    &client,
+                    target.clone(),
+                    version,
+                    req.headers(),
+                    CaptureMode::HttpsTransparent,
+                )
+                .await;
+                return Ok(resp);
+            }
+            PolicyRuleAction::Allow => {
+                let resp = proxy_allowed_request(
+                    state.clone(),
+                    request_id,
+                    full_url,
+                    method,
+                    version,
+                    client,
+                    target,
+                    req,
+                    CaptureMode::HttpsTransparent,
+                    rule.request_timeout_ms,
+                    rule.header_actions.clone(),
+                    state.egress_request_header_actions.clone(),
+                )
+                .await;
+                return Ok(resp);
+            }
+            PolicyRuleAction::Delegate => {
+                let Some(profile_name) = rule.external_auth_profile.as_ref() else {
+                    let resp = build_external_auth_error_response(
+                        &state,
+                        &request_id,
+                        &full_url,
+                        &method,
+                        &client,
+                        target,
+                        version,
+                        req.headers(),
+                        CaptureMode::HttpsTransparent,
+                        "ExternalApprovalError",
+                        "External auth profile not found",
+                    )
+                    .await;
+                    return Ok(resp);
+                };
+
+                let Some(target_endpoint) = target.clone() else {
+                    let resp = build_external_auth_error_response(
+                        &state,
+                        &request_id,
+                        &full_url,
+                        &method,
+                        &client,
+                        target,
+                        version,
+                        req.headers(),
+                        CaptureMode::HttpsTransparent,
+                        "ExternalApprovalError",
+                        "Missing target for transparent HTTPS request",
+                    )
+                    .await;
+                    return Ok(resp);
+                };
+
+                let profile_cfg = state.config.policy.external_auth_profiles.get(profile_name);
+                let gate_result = match profile_cfg.map(|cfg| &cfg.profile_type) {
+                    Some(ExternalAuthProfileType::Http) => {
+                        if let Some(profile) = state.external_auth.get_profile(profile_name) {
+                            run_external_auth_gate_lifecycle(
                                 state.clone(),
                                 &request_id,
                                 &full_url,
                                 &method,
                                 &client,
-                                target_endpoint,
+                                Some(target_endpoint),
                                 version,
                                 req,
                                 &client_ip_for_policy,
@@ -310,12 +398,12 @@ async fn handle_inner_https_request(
                                 rule.rule_id.clone(),
                                 &profile,
                                 profile_name,
-                                request_timeout_ms,
-                                header_actions,
-                                egress_request_header_actions.clone(),
+                                rule.request_timeout_ms,
+                                rule.header_actions.clone(),
+                                state.egress_request_header_actions.clone(),
+                                CaptureMode::HttpsTransparent,
                             )
-                            .await;
-                            return Ok(resp);
+                            .await
                         } else {
                             let resp = build_external_auth_error_response(
                                 &state,
@@ -328,17 +416,15 @@ async fn handle_inner_https_request(
                                 req.headers(),
                                 CaptureMode::HttpsTransparent,
                                 "ExternalApprovalError",
-                                "Missing target for transparent HTTPS request",
+                                "External auth profile not found",
                             )
                             .await;
                             return Ok(resp);
                         }
                     }
-                }
-                Some(ExternalAuthProfileType::Plugin) => {
-                    if let Some(handler) = state.auth_plugins.get_handler(profile_name) {
-                        if let Some(target_endpoint) = target.clone() {
-                            let resp = run_auth_plugin_gate_lifecycle(
+                    Some(ExternalAuthProfileType::Plugin) => {
+                        if let Some(handler) = state.auth_plugins.get_handler(profile_name) {
+                            run_auth_plugin_gate_lifecycle(
                                 state.clone(),
                                 &request_id,
                                 &full_url,
@@ -350,13 +436,12 @@ async fn handle_inner_https_request(
                                 &client_ip_for_policy,
                                 profile_name,
                                 &handler,
-                                request_timeout_ms,
-                                header_actions,
-                                egress_request_header_actions.clone(),
+                                rule.request_timeout_ms,
+                                rule.header_actions.clone(),
+                                state.egress_request_header_actions.clone(),
                                 CaptureMode::HttpsTransparent,
                             )
-                            .await;
-                            return Ok(resp);
+                            .await
                         } else {
                             let resp = build_external_auth_error_response(
                                 &state,
@@ -369,91 +454,41 @@ async fn handle_inner_https_request(
                                 req.headers(),
                                 CaptureMode::HttpsTransparent,
                                 "ExternalApprovalError",
-                                "Missing target for transparent HTTPS request",
+                                "External auth profile not found",
                             )
                             .await;
                             return Ok(resp);
                         }
                     }
-                }
-                None => {}
-            }
+                    None => {
+                        let resp = build_external_auth_error_response(
+                            &state,
+                            &request_id,
+                            &full_url,
+                            &method,
+                            &client,
+                            target,
+                            version,
+                            req.headers(),
+                            CaptureMode::HttpsTransparent,
+                            "ExternalApprovalError",
+                            "External auth profile not found",
+                        )
+                        .await;
+                        return Ok(resp);
+                    }
+                };
 
-            let resp = build_external_auth_error_response(
-                &state,
-                &request_id,
-                &full_url,
-                &method,
-                &client,
-                target,
-                version,
-                req.headers(),
-                CaptureMode::HttpsTransparent,
-                "ExternalApprovalError",
-                "External auth profile not found",
-            )
-            .await;
-            return Ok(resp);
+                match gate_result {
+                    ExternalAuthGateResult::Response(resp) => return Ok(resp),
+                    ExternalAuthGateResult::Pass(original_req) => {
+                        req = original_req;
+                        start_index = rule.index + 1;
+                    }
+                }
+            }
         }
     }
-
-    let resp = proxy_allowed_request(
-        state.clone(),
-        request_id,
-        full_url,
-        method,
-        version,
-        client,
-        target,
-        req,
-        CaptureMode::HttpsTransparent,
-        request_timeout_ms,
-        header_actions,
-        egress_request_header_actions,
-    )
-    .await;
-
-    Ok(resp)
-}
-
-async fn handle_https_transparent_external_auth_gate(
-    state: Arc<AppState>,
-    request_id: &str,
-    url: &str,
-    method: &http::Method,
-    client: &CaptureEndpoint,
-    target: CaptureEndpoint,
-    version: http::Version,
-    req: Request<Body>,
-    client_ip_for_policy: &str,
-    rule_index: usize,
-    rule_id: Option<String>,
-    profile: &crate::external_auth::ExternalAuthProfile,
-    profile_name: &str,
-    request_timeout_ms: Option<u64>,
-    header_actions: Vec<crate::policy::CompiledHeaderAction>,
-    egress_request_header_actions: Vec<crate::policy::CompiledHeaderAction>,
-) -> Response<Body> {
-    run_external_auth_gate_lifecycle(
-        state,
-        request_id,
-        url,
-        method,
-        client,
-        Some(target),
-        version,
-        req,
-        client_ip_for_policy,
-        rule_index,
-        rule_id,
-        profile,
-        profile_name,
-        request_timeout_ms,
-        header_actions,
-        egress_request_header_actions,
-        CaptureMode::HttpsTransparent,
-    )
-    .await
 }
 
 fn build_https_url_for_transparent(

--- a/tests/config_reload.rs
+++ b/tests/config_reload.rs
@@ -173,7 +173,7 @@ async fn loop_header_injection_updates_after_reload() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "http://{}:{}/**",
                 upstream_addr.ip(),
@@ -259,7 +259,7 @@ async fn failed_reload_keeps_previous_state() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "http://{}:{}/**",
                 upstream_addr.ip(),
@@ -412,7 +412,7 @@ async fn egress_forwarding_enable_disable_updates_after_reload() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "http://{}:{}/**",
                 direct_addr.ip(),

--- a/tests/egress_forwarding_chain.rs
+++ b/tests/egress_forwarding_chain.rs
@@ -6,7 +6,7 @@ use acl_proxy::app::AppState;
 use acl_proxy::capture::{CaptureKind, CaptureMode, CaptureRecord};
 use acl_proxy::config::{
     Config, EgressTargetConfig, HeaderActionConfig, HeaderActionKind, HeaderDirection, HeaderWhen,
-    PolicyDefaultAction, PolicyRuleConfig, PolicyRuleDirectConfig,
+    PolicyDefaultAction, PolicyRuleAction, PolicyRuleConfig, PolicyRuleDirectConfig,
 };
 use acl_proxy::proxy::http::run_http_proxy_on_listener;
 use h2::client as h2_client;
@@ -183,7 +183,7 @@ default = "deny"
 
 fn allow_rule(pattern: String, header_actions: Vec<HeaderActionConfig>) -> PolicyRuleConfig {
     PolicyRuleConfig::Direct(PolicyRuleDirectConfig {
-        action: PolicyDefaultAction::Allow,
+        action: PolicyRuleAction::Allow,
         pattern: Some(pattern),
         patterns: None,
         description: None,

--- a/tests/policy_cli.rs
+++ b/tests/policy_cli.rs
@@ -284,6 +284,59 @@ description = "OpenAI docs and repositories"
 }
 
 #[test]
+fn policy_dump_json_renders_delegate_action_and_external_auth_profile() {
+    let mut file = NamedTempFile::new().expect("create temp config");
+    file.write_all(
+        br#"
+schema_version = "1"
+
+[proxy]
+bind_address = "127.0.0.1"
+http_port = 8080
+
+[logging]
+directory = "logs"
+level = "info"
+
+[policy]
+default = "deny"
+
+[policy.external_auth_profiles.example_delegate]
+webhook_url = "https://auth.internal/start"
+timeout_ms = 5000
+
+[[policy.rules]]
+action = "delegate"
+pattern = "https://example.com/**"
+external_auth_profile = "example_delegate"
+description = "Delegate example"
+        "#,
+    )
+    .expect("write config");
+
+    let mut cmd = Command::new(assert_cmd::cargo_bin!("acl-proxy"));
+    cmd.arg("policy")
+        .arg("dump")
+        .arg("--format")
+        .arg("json")
+        .arg("--config")
+        .arg(file.path());
+
+    let assert = cmd.assert().success();
+    let stdout =
+        String::from_utf8(assert.get_output().stdout.clone()).expect("stdout is valid UTF-8");
+    let value: Value = serde_json::from_str(&stdout).expect("output is valid JSON");
+    let rules = value["rules"].as_array().expect("rules is an array");
+    assert_eq!(rules.len(), 1);
+
+    let rule = &rules[0];
+    assert_eq!(rule["action"], "delegate");
+    assert_eq!(rule["pattern"], "https://example.com/**");
+    assert_eq!(rule["description"], "Delegate example");
+    assert_eq!(rule["external_auth"]["profile"], "example_delegate");
+}
+
+#[test]
 fn policy_dump_table_expands_patterns_to_rows() {
     let mut file = NamedTempFile::new().expect("create temp config");
     file.write_all(

--- a/tests/proxy_http.rs
+++ b/tests/proxy_http.rs
@@ -656,6 +656,241 @@ value = "static"
     assert_eq!(deny_status, StatusCode::FORBIDDEN);
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn external_auth_callback_pass_falls_through_to_later_allow() {
+    let (upstream_addr, seen_headers) = start_upstream_echo_server().await;
+
+    let proxy_addr_shared: Arc<Mutex<Option<SocketAddr>>> = Arc::new(Mutex::new(None));
+    let proxy_addr_for_svc = proxy_addr_shared.clone();
+
+    let make_svc = make_service_fn(move |_conn| {
+        let proxy_addr_for_svc = proxy_addr_for_svc.clone();
+        async move {
+            Ok::<_, hyper::Error>(service_fn(move |req: Request<Body>| {
+                let proxy_addr_for_svc = proxy_addr_for_svc.clone();
+                async move {
+                    let event_header = req
+                        .headers()
+                        .get("x-acl-proxy-event")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or("")
+                        .to_ascii_lowercase();
+
+                    let bytes = hyper::body::to_bytes(req.into_body())
+                        .await
+                        .unwrap_or_default();
+                    let body: serde_json::Value =
+                        serde_json::from_slice(&bytes).unwrap_or_else(|_| serde_json::json!({}));
+
+                    if event_header == "pending" {
+                        if let Some(request_id) = body
+                            .get("requestId")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string())
+                        {
+                            if let Some(proxy_addr) = *proxy_addr_for_svc.lock().unwrap() {
+                                let callback_body = serde_json::json!({
+                                    "requestId": request_id,
+                                    "decision": "pass"
+                                });
+                                let client = hyper::Client::new();
+                                let uri = format!(
+                                    "http://{}/_acl-proxy/external-auth/callback",
+                                    proxy_addr
+                                );
+                                tokio::spawn(async move {
+                                    let req = Request::builder()
+                                        .method("POST")
+                                        .uri(uri)
+                                        .header(
+                                            http::header::CONTENT_TYPE,
+                                            HeaderValue::from_static("application/json"),
+                                        )
+                                        .body(Body::from(
+                                            serde_json::to_vec(&callback_body)
+                                                .unwrap_or_else(|_| b"{}".to_vec()),
+                                        ))
+                                        .unwrap();
+                                    let _ = client.request(req).await;
+                                });
+                            }
+                        }
+                    }
+
+                    Ok::<_, hyper::Error>(Response::new(Body::from("ok")))
+                }
+            }))
+        }
+    });
+
+    let webhook_listener = StdTcpListener::bind("127.0.0.1:0").expect("bind webhook");
+    webhook_listener
+        .set_nonblocking(true)
+        .expect("set nonblocking webhook");
+    let webhook_addr = webhook_listener.local_addr().expect("webhook addr");
+    tokio::spawn(
+        Server::from_tcp(webhook_listener)
+            .expect("server from tcp")
+            .serve(make_svc),
+    );
+
+    let host = format!("{}:{}", upstream_addr.ip(), upstream_addr.port());
+    let toml = format!(
+        r#"
+schema_version = "1"
+
+[proxy]
+bind_address = "127.0.0.1"
+http_port = 0
+
+[logging]
+directory = "logs"
+level = "info"
+
+[capture]
+allowed_request = false
+allowed_response = false
+denied_request = false
+denied_response = false
+directory = "logs-capture"
+
+[policy]
+default = "deny"
+
+[policy.external_auth_profiles]
+[policy.external_auth_profiles.pass_profile]
+webhook_url = "http://{webhook_addr}/webhook"
+timeout_ms = 5000
+webhook_timeout_ms = 1000
+on_webhook_failure = "error"
+
+[[policy.rules]]
+action = "delegate"
+pattern = "http://{host}/**"
+external_auth_profile = "pass_profile"
+
+[[policy.rules.header_actions]]
+direction = "request"
+action = "set"
+name = "x-delegate-pass"
+value = "should-not-apply"
+
+[[policy.rules]]
+action = "allow"
+pattern = "http://{host}/**"
+"#,
+        webhook_addr = webhook_addr,
+        host = host
+    );
+
+    let config: Config = toml::from_str(&toml).expect("parse config");
+    let proxy_listener = StdTcpListener::bind("127.0.0.1:0").expect("bind proxy");
+    proxy_listener
+        .set_nonblocking(true)
+        .expect("set nonblocking proxy");
+    let (proxy_addr, _temp_dir) = start_proxy_with_config(config, proxy_listener).await;
+    *proxy_addr_shared.lock().unwrap() = Some(proxy_addr);
+
+    let raw_request =
+        format!("GET http://{host}/ok HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n");
+    let (_response, status) = send_raw_http_request(proxy_addr, &raw_request).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let headers_guard = seen_headers.lock().unwrap();
+    let upstream_headers = headers_guard.as_ref().expect("upstream should see request");
+    assert!(upstream_headers.get("x-delegate-pass").is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn auth_plugin_pass_falls_through_to_later_allow() {
+    let (upstream_addr, seen_headers) = start_upstream_echo_server().await;
+
+    let temp_dir = TempDir::new().expect("temp dir");
+    let script_path = temp_dir.path().join("auth-plugin-pass.sh");
+    let script = r#"#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf "%s" "$line" | sed -n 's/.*"id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+  if [ -n "$id" ]; then
+    printf '{"id":"%s","type":"response","decision":"pass"}\n' "$id"
+  fi
+done
+"#;
+    std::fs::write(&script_path, script).expect("write plugin script");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path)
+            .expect("stat plugin script")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).expect("chmod plugin script");
+    }
+
+    let host = format!("{}:{}", upstream_addr.ip(), upstream_addr.port());
+    let toml = format!(
+        r#"
+schema_version = "1"
+
+[proxy]
+bind_address = "127.0.0.1"
+http_port = 0
+
+[logging]
+directory = "logs"
+level = "info"
+
+[capture]
+allowed_request = false
+allowed_response = false
+denied_request = false
+denied_response = false
+directory = "logs-capture"
+
+[policy]
+default = "deny"
+
+[policy.external_auth_profiles]
+[policy.external_auth_profiles.pass_plugin]
+type = "plugin"
+command = "{script_path}"
+timeout_ms = 1000
+
+[[policy.rules]]
+action = "delegate"
+pattern = "http://{host}/**"
+external_auth_profile = "pass_plugin"
+
+[[policy.rules.header_actions]]
+direction = "request"
+action = "set"
+name = "x-delegate-pass"
+value = "should-not-apply"
+
+[[policy.rules]]
+action = "allow"
+pattern = "http://{host}/**"
+"#,
+        script_path = script_path.to_string_lossy(),
+        host = host
+    );
+
+    let config: Config = toml::from_str(&toml).expect("parse config");
+    let proxy_listener = StdTcpListener::bind("127.0.0.1:0").expect("bind proxy");
+    proxy_listener
+        .set_nonblocking(true)
+        .expect("set nonblocking proxy");
+    let (proxy_addr, _temp_dir) = start_proxy_with_config(config, proxy_listener).await;
+
+    let raw_request =
+        format!("GET http://{host}/ok HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n");
+    let (_response, status) = send_raw_http_request(proxy_addr, &raw_request).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let headers_guard = seen_headers.lock().unwrap();
+    let upstream_headers = headers_guard.as_ref().expect("upstream should see request");
+    assert!(upstream_headers.get("x-delegate-pass").is_none());
+}
+
 fn minimal_config() -> Config {
     let toml = r#"
 schema_version = "1"

--- a/tests/proxy_http.rs
+++ b/tests/proxy_http.rs
@@ -223,7 +223,7 @@ webhook_timeout_ms = 200
 on_webhook_failure = "error"
 
 [[policy.rules]]
-action = "allow"
+action = "delegate"
 pattern = "http://example.com/**"
 description = "External auth test rule"
 external_auth_profile = "test_profile"
@@ -435,7 +435,7 @@ webhook_timeout_ms = 1000
 on_webhook_failure = "error"
 
 [[policy.rules]]
-action = "allow"
+action = "delegate"
 pattern = "http://{host}/**"
 description = "External auth with macros"
 external_auth_profile = "test_profile"
@@ -611,7 +611,7 @@ timeout_ms = 1000
 include_headers = ["authorization"]
 
 [[policy.rules]]
-action = "allow"
+action = "delegate"
 pattern = "http://{host}/**"
 external_auth_profile = "gitlab_acl"
 
@@ -759,7 +759,7 @@ async fn allowed_request_uses_configured_egress_forwarding_destination() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some("http://example.invalid/**".to_string()),
             patterns: None,
             description: None,
@@ -820,7 +820,7 @@ async fn global_egress_request_actions_are_applied_after_rule_actions_without_af
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![
         acl_proxy::config::PolicyRuleConfig::Direct(acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Deny,
+            action: acl_proxy::config::PolicyRuleAction::Deny,
             pattern: Some("http://example.invalid/**".to_string()),
             patterns: None,
             description: None,
@@ -836,7 +836,7 @@ async fn global_egress_request_actions_are_applied_after_rule_actions_without_af
             rule_id: None,
         }),
         acl_proxy::config::PolicyRuleConfig::Direct(acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some("http://example.invalid/**".to_string()),
             patterns: None,
             description: None,
@@ -983,7 +983,7 @@ async fn global_egress_request_actions_respect_intra_layer_order() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some("http://example.invalid/**".to_string()),
             patterns: None,
             description: None,
@@ -1072,7 +1072,7 @@ async fn empty_global_egress_actions_preserve_existing_rule_header_behavior() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some("http://example.invalid/**".to_string()),
             patterns: None,
             description: None,
@@ -1255,7 +1255,7 @@ webhook_timeout_ms = 1000
 on_webhook_failure = "error"
 
 [[policy.rules]]
-action = "allow"
+action = "delegate"
 pattern = "http://example.invalid/**"
 external_auth_profile = "test_profile"
         "#,
@@ -1403,7 +1403,7 @@ async fn http_explicit_listener_accepts_h2c_prior_knowledge_requests() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "http://{}:{}/**",
                 upstream_addr.ip(),
@@ -1449,7 +1449,7 @@ async fn allowed_request_is_proxied_and_loop_header_added() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "http://{}:{}/**",
                 upstream_addr.ip(),
@@ -1517,7 +1517,7 @@ async fn headers_absent_top_deny_guard_falls_through_to_allow_rule() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![
         acl_proxy::config::PolicyRuleConfig::Direct(acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Deny,
+            action: acl_proxy::config::PolicyRuleAction::Deny,
             pattern: Some(format!("http://{host}/**")),
             patterns: None,
             description: Some("Deny requests missing identity".to_string()),
@@ -1533,7 +1533,7 @@ async fn headers_absent_top_deny_guard_falls_through_to_allow_rule() {
             rule_id: None,
         }),
         acl_proxy::config::PolicyRuleConfig::Direct(acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!("http://{host}/**")),
             patterns: None,
             description: Some("Allow upstream traffic".to_string()),
@@ -1600,7 +1600,7 @@ async fn method_scoped_headers_absent_guard_only_blocks_matching_methods() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![
         acl_proxy::config::PolicyRuleConfig::Direct(acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Deny,
+            action: acl_proxy::config::PolicyRuleAction::Deny,
             pattern: Some(format!("http://{host}/**")),
             patterns: None,
             description: Some("Deny POSTs missing identity".to_string()),
@@ -1625,7 +1625,7 @@ async fn method_scoped_headers_absent_guard_only_blocks_matching_methods() {
             rule_id: None,
         }),
         acl_proxy::config::PolicyRuleConfig::Direct(acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!("http://{host}/**")),
             patterns: None,
             description: Some("Allow upstream traffic".to_string()),
@@ -1691,7 +1691,7 @@ async fn headers_match_top_guard_denies_non_matching_value_and_allows_matching_v
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![
         acl_proxy::config::PolicyRuleConfig::Direct(acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!("http://{host}/**")),
             patterns: None,
             description: Some("Allow trusted identity header".to_string()),
@@ -1710,7 +1710,7 @@ async fn headers_match_top_guard_denies_non_matching_value_and_allows_matching_v
             rule_id: None,
         }),
         acl_proxy::config::PolicyRuleConfig::Direct(acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Deny,
+            action: acl_proxy::config::PolicyRuleAction::Deny,
             pattern: Some(format!("http://{host}/**")),
             patterns: None,
             description: Some("Deny all other traffic".to_string()),
@@ -1775,7 +1775,7 @@ async fn headers_match_http_regressions_cover_repeated_values_comma_literals_and
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!("http://{host}/**")),
             patterns: None,
             description: Some("Allow only exact trusted header values".to_string()),
@@ -1860,7 +1860,7 @@ async fn loop_header_not_added_when_disabled() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "http://{}:{}/**",
                 upstream_addr.ip(),
@@ -2014,7 +2014,7 @@ async fn origin_form_request_with_host_is_forwarded() {
     let host = format!("{}:{}", upstream_addr.ip(), upstream_addr.port());
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!("http://{host}/**")),
             patterns: None,
             description: None,
@@ -2078,7 +2078,7 @@ async fn upstream_connection_failure_returns_502() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some("http://127.0.0.1:1/**".to_string()),
             patterns: None,
             description: None,
@@ -2124,7 +2124,7 @@ async fn upstream_request_timeout_returns_504() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "http://{}:{}/**",
                 upstream_addr.ip(),

--- a/tests/proxy_https_connect.rs
+++ b/tests/proxy_https_connect.rs
@@ -335,7 +335,7 @@ async fn allowed_https_via_connect_is_proxied_and_captured() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "https://{}:{}/**",
                 upstream_addr.ip(),
@@ -426,7 +426,7 @@ async fn configured_egress_forwarding_applies_to_https_connect_inner_requests() 
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some("https://connect-target.test:9443/**".to_string()),
             patterns: None,
             description: None,
@@ -485,7 +485,7 @@ async fn global_egress_request_actions_apply_to_https_connect_inner_requests() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some("https://connect-target.test:9443/**".to_string()),
             patterns: None,
             description: None,
@@ -552,7 +552,7 @@ async fn denied_https_via_connect_returns_403() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "https://{}:{}/ok",
                 upstream_addr.ip(),
@@ -604,7 +604,7 @@ async fn headers_match_is_evaluated_on_decrypted_inner_connect_requests() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some("https://connect-target.test:9443/**".to_string()),
             patterns: None,
             description: Some("Allow trusted workload identities".to_string()),
@@ -689,7 +689,7 @@ async fn loop_detected_on_connect_returns_508() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "https://{}:{}/**",
                 upstream_addr.ip(),

--- a/tests/proxy_https_connect.rs
+++ b/tests/proxy_https_connect.rs
@@ -595,6 +595,94 @@ async fn denied_https_via_connect_returns_403() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn delegate_plugin_pass_falls_through_for_connect_inner_request() {
+    let upstream_addr = start_upstream_https_echo_server().await;
+
+    let plugin_temp_dir = TempDir::new().expect("temp dir");
+    let script_path = plugin_temp_dir.path().join("auth-plugin-pass.sh");
+    let script = r#"#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf "%s" "$line" | sed -n 's/.*"id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+  if [ -n "$id" ]; then
+    printf '{"id":"%s","type":"response","decision":"pass"}\n' "$id"
+  fi
+done
+"#;
+    std::fs::write(&script_path, script).expect("write plugin script");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path)
+            .expect("stat plugin script")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).expect("chmod plugin script");
+    }
+
+    let host = format!("{}:{}", upstream_addr.ip(), upstream_addr.port());
+    let toml = format!(
+        r#"
+schema_version = "1"
+
+[proxy]
+bind_address = "127.0.0.1"
+http_port = 0
+
+[logging]
+directory = "logs"
+level = "info"
+
+[capture]
+allowed_request = false
+allowed_response = false
+denied_request = false
+denied_response = false
+directory = "logs-capture"
+
+[certificates]
+certs_dir = "certs"
+
+[tls]
+verify_upstream = false
+
+[policy]
+default = "deny"
+
+[policy.external_auth_profiles]
+[policy.external_auth_profiles.pass_plugin]
+type = "plugin"
+command = "{script_path}"
+timeout_ms = 1000
+
+[[policy.rules]]
+action = "delegate"
+pattern = "https://{host}/**"
+external_auth_profile = "pass_plugin"
+
+[[policy.rules]]
+action = "allow"
+pattern = "https://{host}/**"
+"#,
+        script_path = script_path.to_string_lossy(),
+        host = host
+    );
+    let config: Config = toml::from_str(&toml).expect("parse config");
+
+    let proxy_listener = StdTcpListener::bind("127.0.0.1:0").expect("bind proxy");
+    proxy_listener
+        .set_nonblocking(true)
+        .expect("set nonblocking proxy");
+    let (proxy_addr, proxy_temp_dir) = start_proxy_with_config(config, proxy_listener).await;
+    let ca_cert_path = proxy_temp_dir.path().join("certs").join("ca-cert.pem");
+
+    let (status, body) =
+        send_https_via_connect(proxy_addr, &ca_cert_path, &host, "/ok").await;
+
+    assert_eq!(status, StatusCode::OK.as_u16());
+    assert_eq!(body, "ok");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn headers_match_is_evaluated_on_decrypted_inner_connect_requests() {
     let (forward_addr, seen_requests) = start_forwarding_echo_server().await;
 

--- a/tests/proxy_https_transparent.rs
+++ b/tests/proxy_https_transparent.rs
@@ -2306,6 +2306,103 @@ async fn denied_https_transparent_returns_403() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn delegate_plugin_pass_falls_through_for_transparent_https_request() {
+    let upstream_addr = start_upstream_https_echo_server().await;
+
+    let plugin_temp_dir = TempDir::new().expect("temp dir");
+    let script_path = plugin_temp_dir.path().join("auth-plugin-pass.sh");
+    let script = r#"#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf "%s" "$line" | sed -n 's/.*"id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+  if [ -n "$id" ]; then
+    printf '{"id":"%s","type":"response","decision":"pass"}\n' "$id"
+  fi
+done
+"#;
+    std::fs::write(&script_path, script).expect("write plugin script");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path)
+            .expect("stat plugin script")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).expect("chmod plugin script");
+    }
+
+    let host_header = format!("{}:{}", upstream_addr.ip(), upstream_addr.port());
+    let toml = format!(
+        r#"
+schema_version = "1"
+
+[proxy]
+bind_address = "127.0.0.1"
+http_port = 0
+https_bind_address = "127.0.0.1"
+https_port = 0
+
+[logging]
+directory = "logs"
+level = "info"
+
+[capture]
+allowed_request = false
+allowed_response = false
+denied_request = false
+denied_response = false
+directory = "logs-capture"
+
+[certificates]
+certs_dir = "certs"
+
+[tls]
+verify_upstream = false
+
+[policy]
+default = "deny"
+
+[policy.external_auth_profiles]
+[policy.external_auth_profiles.pass_plugin]
+type = "plugin"
+command = "{script_path}"
+timeout_ms = 1000
+
+[[policy.rules]]
+action = "delegate"
+pattern = "https://{host_header}/**"
+external_auth_profile = "pass_plugin"
+
+[[policy.rules]]
+action = "allow"
+pattern = "https://{host_header}/**"
+"#,
+        script_path = script_path.to_string_lossy(),
+        host_header = host_header
+    );
+    let config: Config = toml::from_str(&toml).expect("parse config");
+
+    let proxy_listener = StdTcpListener::bind("127.0.0.1:0").expect("bind proxy");
+    proxy_listener
+        .set_nonblocking(true)
+        .expect("set nonblocking proxy");
+    let (proxy_addr, _temp_dir, ca_cert_path) =
+        start_proxy_with_config(config, proxy_listener).await;
+
+    let (status, body) = send_https_request_via_transparent(
+        proxy_addr,
+        &ca_cert_path,
+        "transparent.test",
+        &host_header,
+        "/ok",
+        &[],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK.as_u16());
+    assert_eq!(body, "ok");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn denied_https_transparent_h2_returns_403() {
     let upstream_addr = start_upstream_https_echo_server().await;
 

--- a/tests/proxy_https_transparent.rs
+++ b/tests/proxy_https_transparent.rs
@@ -682,7 +682,7 @@ async fn allowed_https_transparent_is_proxied_and_captured() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "https://{}:{}/**",
                 upstream_addr.ip(),
@@ -781,7 +781,7 @@ async fn configured_egress_forwarding_applies_to_https_transparent_requests() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some("https://transparent-target.test:9443/**".to_string()),
             patterns: None,
             description: None,
@@ -847,7 +847,7 @@ async fn global_egress_request_actions_apply_to_https_transparent_requests() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some("https://transparent-target.test:9443/**".to_string()),
             patterns: None,
             description: None,
@@ -922,7 +922,7 @@ async fn transparent_https_websocket_upgrade_is_tunneled() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "https://{}:{}/ws",
                 upstream_addr.ip(),
@@ -1046,7 +1046,7 @@ async fn allowed_https_transparent_h2_is_proxied_and_captured() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "https://{}:{}/**",
                 upstream_addr.ip(),
@@ -1161,7 +1161,7 @@ async fn upstream_failure_https_transparent_is_captured() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "https://{}:{}/**",
                 upstream_addr.ip(),
@@ -1273,7 +1273,7 @@ async fn concurrent_h2_streams_share_connection_and_are_captured() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "https://{}:{}/**",
                 upstream_addr.ip(),
@@ -1473,7 +1473,7 @@ async fn concurrent_h2_streams_mixed_allow_and_deny() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "https://{}:{}/ok",
                 upstream_addr.ip(),
@@ -1686,7 +1686,7 @@ async fn large_h2_request_body_is_truncated_in_capture() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "https://{}:{}/large-request",
                 upstream_addr.ip(),
@@ -1813,7 +1813,7 @@ async fn large_h2_response_body_is_truncated_in_capture() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "https://{}:{}/large-response",
                 upstream_addr.ip(),
@@ -1944,7 +1944,7 @@ async fn h2_client_to_http1_only_upstream_preserves_versions_in_capture() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "https://{}:{}/ok",
                 upstream_addr.ip(),
@@ -2066,7 +2066,7 @@ async fn h2_client_to_h2_capable_upstream_preserves_h2_in_capture() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "https://{}:{}/ok",
                 upstream_addr.ip(),
@@ -2184,7 +2184,7 @@ async fn denied_https_transparent_returns_403() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "https://{}:{}/ok",
                 upstream_addr.ip(),
@@ -2314,7 +2314,7 @@ async fn denied_https_transparent_h2_returns_403() {
     config.policy.default = acl_proxy::config::PolicyDefaultAction::Deny;
     config.policy.rules = vec![acl_proxy::config::PolicyRuleConfig::Direct(
         acl_proxy::config::PolicyRuleDirectConfig {
-            action: acl_proxy::config::PolicyDefaultAction::Allow,
+            action: acl_proxy::config::PolicyRuleAction::Allow,
             pattern: Some(format!(
                 "https://{}:{}/ok",
                 upstream_addr.ip(),


### PR DESCRIPTION
Adds first-class action = "delegate" policy rules with external-auth allow/deny/pass semantics, resumable policy evaluation, HTTP/plugin pass support, proxy-mode coverage, docs, and changelog updates.
