### PR TITLE
Support env vars in redaction literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Added
+
+- Support environment variable interpolation for redaction profile replacements and literal rules. ([#55](https://github.com/kcosr/acl-proxy/pull/55))
 
 ## [0.1.2] - 2026-06-09
 

--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ pattern = "https://github.com/**"
 
 **`value` / `values`**: Exactly one must be provided for `set`/`add`. Values must be valid HTTP header values.
 
-**Environment variable interpolation**: Exact whole-string `${NAME}` placeholders in `value`/`values` resolve once at config load/reload time. `NAME` must match `[A-Za-z_][A-Za-z0-9_]*`. Mixed strings like `Bearer ${TOKEN}` are rejected. Missing env vars fail validation, startup, and reload.
+**Environment variable interpolation**: Exact whole-string `${NAME}` placeholders in header action `value`/`values`, redaction profile `replacement`, and redaction rule `literals` resolve once at config load/reload time. `NAME` must match `[A-Za-z_][A-Za-z0-9_]*`. Mixed strings like `Bearer ${TOKEN}` are rejected. Missing env vars fail validation, startup, and reload.
 
 **Approval macros**: `{{name}}` placeholders are a separate feature for external auth workflows — they are not resolved at config load time. See [External Auth](#external-auth).
 
@@ -782,6 +782,8 @@ match = "text"                    # text | binary | both
 Profiles redact outbound/request-side data only. For normal HTTP requests with a body, acl-proxy buffers the request body, decompresses supported `Content-Encoding` values, applies literal and regex redaction in-process, recompresses with the original encoding, updates body headers, and forwards upstream. Bodyless requests are forwarded without body-header rewrites. For HTTP/1.1 WebSocket upgrades, acl-proxy applies the same profile to client-to-upstream data messages after an allowed `101 Switching Protocols`; upstream-to-client messages are not redacted or message-buffered.
 
 Profiles are intended for short, known secrets such as fixed passwords or tokens. `replacement` is fixed per profile and can have any length. A redacted upgrade whose `Upgrade` header is not `websocket` is rejected before upstream forwarding. If the upstream negotiates unsupported WebSocket extensions, acl-proxy returns `502 Bad Gateway` before delivering `101 Switching Protocols` to the client.
+
+Redaction `replacement` and `literals` support exact whole-string `${NAME}` environment placeholders. Placeholders are resolved during config load and reload; missing variables or mixed literal/env strings fail validation. Regex `expressions` do not support environment interpolation.
 
 Regex `expressions` use Rust regex syntax, are text-only, and cannot be used with `match = "binary"`. Expressions that can match empty text are rejected to avoid unbounded replacement expansion.
 

--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ pattern = "https://github.com/**"
 
 **`value` / `values`**: Exactly one must be provided for `set`/`add`. Values must be valid HTTP header values.
 
-**Environment variable interpolation**: Exact whole-string `${NAME}` placeholders in header action `value`/`values`, redaction profile `replacement`, and redaction rule `literals` resolve once at config load/reload time. `NAME` must match `[A-Za-z_][A-Za-z0-9_]*`. Complete `${...}` sequences trigger interpolation validation; mixed strings like `Bearer ${TOKEN}` are rejected, while incomplete markers like `${TOKEN` are treated as literal text. Missing env vars fail validation, startup, and reload.
+**Environment variable interpolation**: Exact whole-string `${NAME}` placeholders in header action `value`/`values`, redaction profile `replacement`, and redaction rule `literals` resolve once at config load/reload time. `NAME` must match `[A-Za-z_][A-Za-z0-9_]*`. Complete `${...}` sequences trigger interpolation validation; mixed strings like `Bearer ${TOKEN}` are rejected, while incomplete markers like `${TOKEN` are treated as literal text with a warning. Missing env vars fail validation, startup, and reload.
 
 **Approval macros**: `{{name}}` placeholders are a separate feature for external auth workflows — they are not resolved at config load time. See [External Auth](#external-auth).
 

--- a/README.md
+++ b/README.md
@@ -783,7 +783,7 @@ Profiles redact outbound/request-side data only. For normal HTTP requests with a
 
 Profiles are intended for short, known secrets such as fixed passwords or tokens. `replacement` is fixed per profile and can have any length. A redacted upgrade whose `Upgrade` header is not `websocket` is rejected before upstream forwarding. If the upstream negotiates unsupported WebSocket extensions, acl-proxy returns `502 Bad Gateway` before delivering `101 Switching Protocols` to the client.
 
-Redaction `replacement` and `literals` support exact whole-string `${NAME}` environment placeholders. Placeholders are resolved during config load and reload; missing variables or mixed literal/env strings fail validation. Regex `expressions` do not support environment interpolation.
+Redaction `replacement` and `literals` support exact whole-string `${NAME}` environment placeholders. Placeholders are resolved during config load and reload; missing variables or mixed literal/env strings fail validation. Literal redaction strings containing `${` are treated as interpolation attempts; supply those values through an exact env placeholder. Regex `expressions` do not support environment interpolation.
 
 Regex `expressions` use Rust regex syntax, are text-only, and cannot be used with `match = "binary"`. Expressions that can match empty text are rejected to avoid unbounded replacement expansion.
 

--- a/README.md
+++ b/README.md
@@ -783,7 +783,7 @@ Profiles redact outbound/request-side data only. For normal HTTP requests with a
 
 Profiles are intended for short, known secrets such as fixed passwords or tokens. `replacement` is fixed per profile and can have any length. A redacted upgrade whose `Upgrade` header is not `websocket` is rejected before upstream forwarding. If the upstream negotiates unsupported WebSocket extensions, acl-proxy returns `502 Bad Gateway` before delivering `101 Switching Protocols` to the client.
 
-Redaction `replacement` and `literals` support exact whole-string `${NAME}` environment placeholders. Placeholders are resolved during config load and reload; missing variables or mixed literal/env strings fail validation. Literal redaction strings containing `${` are treated as interpolation attempts; supply those values through an exact env placeholder. Regex `expressions` do not support environment interpolation.
+Redaction `replacement` and `literals` support exact whole-string `${NAME}` environment placeholders. Placeholders are resolved during config load and reload; missing variables or mixed literal/env strings fail validation. Literal redaction strings containing complete `${...}` sequences are treated as interpolation attempts; supply those values through an exact env placeholder. Regex `expressions` do not support environment interpolation.
 
 Regex `expressions` use Rust regex syntax, are text-only, and cannot be used with `match = "binary"`. Expressions that can match empty text are rejected to avoid unbounded replacement expansion.
 

--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ pattern = "https://github.com/**"
 
 **`value` / `values`**: Exactly one must be provided for `set`/`add`. Values must be valid HTTP header values.
 
-**Environment variable interpolation**: Exact whole-string `${NAME}` placeholders in header action `value`/`values`, redaction profile `replacement`, and redaction rule `literals` resolve once at config load/reload time. `NAME` must match `[A-Za-z_][A-Za-z0-9_]*`. Mixed strings like `Bearer ${TOKEN}` are rejected. Missing env vars fail validation, startup, and reload.
+**Environment variable interpolation**: Exact whole-string `${NAME}` placeholders in header action `value`/`values`, redaction profile `replacement`, and redaction rule `literals` resolve once at config load/reload time. `NAME` must match `[A-Za-z_][A-Za-z0-9_]*`. Complete `${...}` sequences trigger interpolation validation; mixed strings like `Bearer ${TOKEN}` are rejected, while incomplete markers like `${TOKEN` are treated as literal text. Missing env vars fail validation, startup, and reload.
 
 **Approval macros**: `{{name}}` placeholders are a separate feature for external auth workflows — they are not resolved at config load time. See [External Auth](#external-auth).
 

--- a/acl-proxy.sample.toml
+++ b/acl-proxy.sample.toml
@@ -133,7 +133,8 @@ max_body_bytes = 1048576
 # replacement = "[REDACTED]"
 # # replacement and literal entries may use exact env placeholders like
 # # "${REDACTION_REPLACEMENT}" or "${GITLAB_TOKEN}". Mixed strings such as
-# # "Bearer ${TOKEN}" are rejected; regex expressions are not interpolated.
+# # "Bearer ${TOKEN}" are rejected. Literal strings containing "${" should be
+# # supplied through env placeholders; regex expressions are not interpolated.
 # max_body_bytes = 10485760
 # max_decoded_body_bytes = 52428800
 # max_frame_bytes = 262144

--- a/acl-proxy.sample.toml
+++ b/acl-proxy.sample.toml
@@ -131,6 +131,9 @@ max_body_bytes = 1048576
 #
 # [redaction.profiles.secrets]
 # replacement = "[REDACTED]"
+# # replacement and literal entries may use exact env placeholders like
+# # "${REDACTION_REPLACEMENT}" or "${GITLAB_TOKEN}". Mixed strings such as
+# # "Bearer ${TOKEN}" are rejected; regex expressions are not interpolated.
 # max_body_bytes = 10485760
 # max_decoded_body_bytes = 52428800
 # max_frame_bytes = 262144

--- a/acl-proxy.sample.toml
+++ b/acl-proxy.sample.toml
@@ -133,8 +133,9 @@ max_body_bytes = 1048576
 # replacement = "[REDACTED]"
 # # replacement and literal entries may use exact env placeholders like
 # # "${REDACTION_REPLACEMENT}" or "${GITLAB_TOKEN}". Mixed strings such as
-# # "Bearer ${TOKEN}" are rejected. Literal strings containing "${" should be
-# # supplied through env placeholders; regex expressions are not interpolated.
+# # "Bearer ${TOKEN}" are rejected. Literal strings containing complete
+# # "${...}" sequences should be supplied through env placeholders; regex
+# # expressions are not interpolated.
 # max_body_bytes = 10485760
 # max_decoded_body_bytes = 52428800
 # max_frame_bytes = 262144

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -125,7 +125,9 @@ pub fn run() -> Result<ExitCode, CliError> {
 
             let _logging_guards = match shared_state.load().logging.init_tracing() {
                 Ok(guards) => {
-                    log_startup(shared_state.load().as_ref());
+                    let state = shared_state.load();
+                    log_config_load_warnings(&state.config);
+                    log_startup(state.as_ref());
                     Some(guards)
                 }
                 Err(err) => {
@@ -151,7 +153,8 @@ pub fn run() -> Result<ExitCode, CliError> {
         }
         Command::Config { command } => match command {
             ConfigCommand::Validate => {
-                let _config = load_config_for_cli(config_path)?;
+                let config = load_config_for_cli(config_path)?;
+                print_config_load_warnings(&config);
                 println!("Configuration is valid");
                 Ok(ExitCode::from(0))
             }
@@ -388,7 +391,26 @@ fn spawn_signal_handlers(
 
 fn reload_from_sources(state: &SharedAppState, config_path: Option<&Path>) -> Result<(), String> {
     let config = Config::load_from_sources(config_path).map_err(|e| e.to_string())?;
-    AppState::reload_shared_from_config(state, config).map_err(|e| e.to_string())
+    let load_warnings = config.load_warnings.clone();
+    AppState::reload_shared_from_config(state, config).map_err(|e| e.to_string())?;
+    log_config_load_warning_messages(&load_warnings);
+    Ok(())
+}
+
+fn log_config_load_warnings(config: &Config) {
+    log_config_load_warning_messages(&config.load_warnings);
+}
+
+fn log_config_load_warning_messages(warnings: &[String]) {
+    for warning in warnings {
+        tracing::warn!(target: "acl_proxy::config", "{warning}");
+    }
+}
+
+fn print_config_load_warnings(config: &Config) {
+    for warning in &config.load_warnings {
+        eprintln!("warning: {warning}");
+    }
 }
 
 fn log_startup(state: &AppState) {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -175,6 +175,7 @@ pub fn run() -> Result<ExitCode, CliError> {
         Command::Policy { command } => match command {
             PolicyCommand::Dump { format } => {
                 let config = load_config_for_cli(config_path)?;
+                print_config_load_warnings(&config);
                 let effective = crate::policy::EffectivePolicy::from_config(&config.policy)
                     .map_err(|e| {
                         CliError::Config(crate::config::ConfigError::Invalid(e.to_string()))

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1066,21 +1066,19 @@ impl Config {
 
     fn interpolate_redaction_env_vars(&mut self) -> Result<(), ConfigError> {
         for (profile_name, profile) in self.redaction.profiles.iter_mut() {
-            interpolate_config_env_value(
+            interpolate_redaction_env_value(
                 &mut profile.replacement,
                 format!("redaction.profiles.{profile_name}.replacement").as_str(),
-                false,
             )?;
 
             for (rule_idx, rule) in profile.rules.iter_mut().enumerate() {
                 for (literal_idx, literal) in rule.literals.iter_mut().enumerate() {
-                    interpolate_config_env_value(
+                    interpolate_redaction_env_value(
                         literal,
                         format!(
                             "redaction.profiles.{profile_name}.rules[{rule_idx}].literals[{literal_idx}]"
                         )
                         .as_str(),
-                        false,
                     )?;
                 }
             }
@@ -1232,6 +1230,21 @@ fn interpolate_header_action_value(
     interpolate_config_env_value(raw_value, action_location, true)
 }
 
+fn interpolate_redaction_env_value(
+    raw_value: &mut String,
+    value_location: &str,
+) -> Result<(), ConfigError> {
+    if has_incomplete_config_env_marker(raw_value) {
+        tracing::warn!(
+            target: "acl_proxy::config",
+            location = %value_location,
+            "redaction value contains '${{' but is not a complete placeholder; treating as literal text"
+        );
+    }
+
+    interpolate_config_env_value(raw_value, value_location, false)
+}
+
 fn interpolate_config_env_value(
     raw_value: &mut String,
     value_location: &str,
@@ -1261,13 +1274,16 @@ fn interpolate_config_env_value(
     }
 }
 
-fn classify_config_env_placeholder(raw_value: &str) -> ConfigEnvPlaceholder<'_> {
+fn has_incomplete_config_env_marker(raw_value: &str) -> bool {
     let Some(open_idx) = raw_value.find("${") else {
-        return ConfigEnvPlaceholder::None;
+        return false;
     };
 
-    let has_closing_brace = raw_value[open_idx + 2..].contains('}');
-    if !has_closing_brace {
+    !raw_value[open_idx + 2..].contains('}')
+}
+
+fn classify_config_env_placeholder(raw_value: &str) -> ConfigEnvPlaceholder<'_> {
+    if has_incomplete_config_env_marker(raw_value) || !raw_value.contains("${") {
         return ConfigEnvPlaceholder::None;
     }
 
@@ -2249,6 +2265,44 @@ redaction_profile = "secrets"
         let profile = config.redaction.profiles.get("secrets").expect("profile");
         assert_eq!(profile.replacement, "[MASKED]");
         assert_eq!(profile.rules[0].literals, vec!["load-secret".to_string()]);
+    }
+
+    #[test]
+    fn load_from_sources_preserves_incomplete_redaction_env_marker_literals() {
+        let mut file = tempfile::NamedTempFile::new().expect("create temp config");
+        write!(
+            file,
+            r#"
+schema_version = "1"
+
+[proxy]
+bind_address = "127.0.0.1"
+http_port = 8080
+
+[logging]
+directory = "logs"
+level = "info"
+
+[redaction.profiles.secrets]
+
+[[redaction.profiles.secrets.rules]]
+literals = ["pass${{word"]
+
+[policy]
+default = "deny"
+
+[[policy.rules]]
+action = "allow"
+pattern = "https://example.com/**"
+redaction_profile = "secrets"
+            "#
+        )
+        .expect("write config");
+
+        let config = Config::load_from_sources(Some(file.path()))
+            .expect("load should preserve incomplete marker literal");
+        let profile = config.redaction.profiles.get("secrets").expect("profile");
+        assert_eq!(profile.rules[0].literals, vec!["pass${word".to_string()]);
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -40,7 +40,7 @@ pub enum ConfigPathKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum HeaderActionEnvPlaceholder<'a> {
+enum ConfigEnvPlaceholder<'a> {
     None,
     Exact { name: &'a str },
     Invalid,
@@ -1007,6 +1007,7 @@ impl Config {
 
         config.apply_env_overrides();
         config.interpolate_header_action_env_vars()?;
+        config.interpolate_redaction_env_vars()?;
         config.validate_basic()?;
 
         Ok(config)
@@ -1059,6 +1060,29 @@ impl Config {
         }
 
         interpolate_egress_request_header_actions(&mut self.proxy.egress.request_header_actions)?;
+
+        Ok(())
+    }
+
+    fn interpolate_redaction_env_vars(&mut self) -> Result<(), ConfigError> {
+        for (profile_name, profile) in self.redaction.profiles.iter_mut() {
+            interpolate_config_env_value(
+                &mut profile.replacement,
+                format!("redaction.profiles.{profile_name}.replacement").as_str(),
+            )?;
+
+            for (rule_idx, rule) in profile.rules.iter_mut().enumerate() {
+                for (literal_idx, literal) in rule.literals.iter_mut().enumerate() {
+                    interpolate_config_env_value(
+                        literal,
+                        format!(
+                            "redaction.profiles.{profile_name}.rules[{rule_idx}].literals[{literal_idx}]"
+                        )
+                        .as_str(),
+                    )?;
+                }
+            }
+        }
 
         Ok(())
     }
@@ -1203,15 +1227,22 @@ fn interpolate_header_action_value(
     raw_value: &mut String,
     action_location: &str,
 ) -> Result<(), ConfigError> {
-    match classify_header_action_env_placeholder(raw_value.as_str()) {
-        HeaderActionEnvPlaceholder::None => Ok(()),
-        HeaderActionEnvPlaceholder::Invalid => Err(ConfigError::Invalid(format!(
-            "{action_location} uses invalid env interpolation syntax: '{raw_value}'"
+    interpolate_config_env_value(raw_value, action_location)
+}
+
+fn interpolate_config_env_value(
+    raw_value: &mut String,
+    value_location: &str,
+) -> Result<(), ConfigError> {
+    match classify_config_env_placeholder(raw_value.as_str()) {
+        ConfigEnvPlaceholder::None => Ok(()),
+        ConfigEnvPlaceholder::Invalid => Err(ConfigError::Invalid(format!(
+            "{value_location} uses invalid env interpolation syntax: '{raw_value}'"
         ))),
-        HeaderActionEnvPlaceholder::Exact { name } => {
+        ConfigEnvPlaceholder::Exact { name } => {
             *raw_value = env::var(name).map_err(|_| {
                 ConfigError::Invalid(format!(
-                    "{action_location} references missing env var '{name}'"
+                    "{value_location} references missing env var '{name}'"
                 ))
             })?;
             Ok(())
@@ -1219,36 +1250,36 @@ fn interpolate_header_action_value(
     }
 }
 
-fn classify_header_action_env_placeholder(raw_value: &str) -> HeaderActionEnvPlaceholder<'_> {
+fn classify_config_env_placeholder(raw_value: &str) -> ConfigEnvPlaceholder<'_> {
     if !raw_value.contains("${") {
-        return HeaderActionEnvPlaceholder::None;
+        return ConfigEnvPlaceholder::None;
     }
 
     let Some(name) = raw_value
         .strip_prefix("${")
         .and_then(|rest| rest.strip_suffix('}'))
     else {
-        return HeaderActionEnvPlaceholder::Invalid;
+        return ConfigEnvPlaceholder::Invalid;
     };
 
     if name.is_empty() {
-        return HeaderActionEnvPlaceholder::Invalid;
+        return ConfigEnvPlaceholder::Invalid;
     }
 
     let mut chars = name.chars();
     let Some(first) = chars.next() else {
-        return HeaderActionEnvPlaceholder::Invalid;
+        return ConfigEnvPlaceholder::Invalid;
     };
 
     if !matches!(first, 'A'..='Z' | 'a'..='z' | '_') {
-        return HeaderActionEnvPlaceholder::Invalid;
+        return ConfigEnvPlaceholder::Invalid;
     }
 
     if !chars.all(|ch| matches!(ch, 'A'..='Z' | 'a'..='z' | '0'..='9' | '_')) {
-        return HeaderActionEnvPlaceholder::Invalid;
+        return ConfigEnvPlaceholder::Invalid;
     }
 
-    HeaderActionEnvPlaceholder::Exact { name }
+    ConfigEnvPlaceholder::Exact { name }
 }
 
 fn format_direct_rule_location(rule_idx: usize) -> String {
@@ -1732,16 +1763,16 @@ mod tests {
     use std::io::Write;
     use std::sync::{Mutex, MutexGuard, OnceLock};
 
-    static HEADER_ACTION_ENV_TEST_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+    static CONFIG_ENV_TEST_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
 
-    struct HeaderActionEnvTestGuard {
+    struct ConfigEnvTestGuard {
         _lock: MutexGuard<'static, ()>,
         saved_vars: Vec<(String, Option<String>)>,
     }
 
-    impl HeaderActionEnvTestGuard {
+    impl ConfigEnvTestGuard {
         fn new(keys: &[&str]) -> Self {
-            let lock = HEADER_ACTION_ENV_TEST_MUTEX
+            let lock = CONFIG_ENV_TEST_MUTEX
                 .get_or_init(|| Mutex::new(()))
                 .lock()
                 .expect("lock env test mutex");
@@ -1772,7 +1803,7 @@ mod tests {
         }
     }
 
-    impl Drop for HeaderActionEnvTestGuard {
+    impl Drop for ConfigEnvTestGuard {
         fn drop(&mut self) {
             for (key, saved_value) in self.saved_vars.iter().rev() {
                 match saved_value {
@@ -2026,6 +2057,129 @@ default = "deny"
         let msg = format!("{err}");
         assert!(
             msg.contains("must not match empty text"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    #[test]
+    fn redaction_env_interpolation_resolves_replacement_and_literals() {
+        let env_guard = ConfigEnvTestGuard::new(&[
+            "ACL_PROXY_TEST_REDACTION_REPLACEMENT",
+            "ACL_PROXY_TEST_REDACTION_LITERAL",
+        ]);
+        env_guard.set("ACL_PROXY_TEST_REDACTION_REPLACEMENT", "[MASKED]");
+        env_guard.set("ACL_PROXY_TEST_REDACTION_LITERAL", "secret-token");
+
+        let toml = r#"
+schema_version = "1"
+
+[proxy]
+bind_address = "127.0.0.1"
+http_port = 8080
+
+[logging]
+directory = "logs"
+level = "debug"
+
+[redaction.profiles.secrets]
+replacement = "${ACL_PROXY_TEST_REDACTION_REPLACEMENT}"
+
+[[redaction.profiles.secrets.rules]]
+literals = ["${ACL_PROXY_TEST_REDACTION_LITERAL}", "static-secret"]
+match = "text"
+
+[policy]
+default = "deny"
+
+[[policy.rules]]
+action = "allow"
+pattern = "https://example.com/**"
+redaction_profile = "secrets"
+        "#;
+
+        let mut config: Config = toml::from_str(toml).expect("parse config");
+        config
+            .interpolate_redaction_env_vars()
+            .expect("interpolation should succeed");
+        config.validate_basic().expect("config should validate");
+
+        let profile = config.redaction.profiles.get("secrets").expect("profile");
+        assert_eq!(profile.replacement, "[MASKED]");
+        assert_eq!(
+            profile.rules[0].literals,
+            vec!["secret-token".to_string(), "static-secret".to_string()]
+        );
+    }
+
+    #[test]
+    fn redaction_env_interpolation_reports_missing_literal_env_var() {
+        let env_guard = ConfigEnvTestGuard::new(&["ACL_PROXY_TEST_MISSING_REDACTION"]);
+        env_guard.remove("ACL_PROXY_TEST_MISSING_REDACTION");
+
+        let toml = r#"
+schema_version = "1"
+
+[proxy]
+bind_address = "127.0.0.1"
+http_port = 8080
+
+[logging]
+directory = "logs"
+level = "debug"
+
+[redaction.profiles.secrets]
+
+[[redaction.profiles.secrets.rules]]
+literals = ["${ACL_PROXY_TEST_MISSING_REDACTION}"]
+
+[policy]
+default = "deny"
+        "#;
+
+        let mut config: Config = toml::from_str(toml).expect("parse config");
+        let err = config
+            .interpolate_redaction_env_vars()
+            .expect_err("missing env var should fail");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains(
+                "redaction.profiles.secrets.rules[0].literals[0] references missing env var 'ACL_PROXY_TEST_MISSING_REDACTION'"
+            ),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    #[test]
+    fn redaction_env_interpolation_rejects_mixed_literal_placeholder() {
+        let toml = r#"
+schema_version = "1"
+
+[proxy]
+bind_address = "127.0.0.1"
+http_port = 8080
+
+[logging]
+directory = "logs"
+level = "debug"
+
+[redaction.profiles.secrets]
+
+[[redaction.profiles.secrets.rules]]
+literals = ["prefix-${ACL_PROXY_TEST_REDACTION_LITERAL}"]
+
+[policy]
+default = "deny"
+        "#;
+
+        let mut config: Config = toml::from_str(toml).expect("parse config");
+        let err = config
+            .interpolate_redaction_env_vars()
+            .expect_err("mixed placeholder should fail");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains(
+                "redaction.profiles.secrets.rules[0].literals[0] uses invalid env interpolation syntax"
+            ),
             "unexpected error message: {msg}"
         );
     }
@@ -3546,18 +3700,18 @@ external_auth_profile = "example"
     }
 
     #[test]
-    fn header_action_env_placeholder_classifier_is_exact_only() {
+    fn config_env_placeholder_classifier_is_exact_only() {
         assert_eq!(
-            classify_header_action_env_placeholder("static-value"),
-            HeaderActionEnvPlaceholder::None
+            classify_config_env_placeholder("static-value"),
+            ConfigEnvPlaceholder::None
         );
         assert_eq!(
-            classify_header_action_env_placeholder("${API_TOKEN}"),
-            HeaderActionEnvPlaceholder::Exact { name: "API_TOKEN" }
+            classify_config_env_placeholder("${API_TOKEN}"),
+            ConfigEnvPlaceholder::Exact { name: "API_TOKEN" }
         );
         assert_eq!(
-            classify_header_action_env_placeholder("${_TOKEN_2}"),
-            HeaderActionEnvPlaceholder::Exact { name: "_TOKEN_2" }
+            classify_config_env_placeholder("${_TOKEN_2}"),
+            ConfigEnvPlaceholder::Exact { name: "_TOKEN_2" }
         );
 
         for raw in [
@@ -3569,8 +3723,8 @@ external_auth_profile = "example"
             "${TOKEN",
         ] {
             assert_eq!(
-                classify_header_action_env_placeholder(raw),
-                HeaderActionEnvPlaceholder::Invalid,
+                classify_config_env_placeholder(raw),
+                ConfigEnvPlaceholder::Invalid,
                 "expected invalid placeholder for {raw}"
             );
         }
@@ -3709,7 +3863,7 @@ value = "Bearer ${{TOKEN}}"
 
     #[test]
     fn header_action_env_interpolation_resolves_exact_value_placeholder() {
-        let env_guard = HeaderActionEnvTestGuard::new(&["ACL_PROXY_TEST_API_TOKEN"]);
+        let env_guard = ConfigEnvTestGuard::new(&["ACL_PROXY_TEST_API_TOKEN"]);
         env_guard.set("ACL_PROXY_TEST_API_TOKEN", "Bearer abc123");
 
         let toml = r#"
@@ -3755,7 +3909,7 @@ value = "${ACL_PROXY_TEST_API_TOKEN}"
     #[test]
     fn header_action_env_interpolation_resolves_mixed_values_and_repeated_placeholder() {
         let env_guard =
-            HeaderActionEnvTestGuard::new(&["ACL_PROXY_TEST_DEPLOYMENT", "ACL_PROXY_TEST_REGION"]);
+            ConfigEnvTestGuard::new(&["ACL_PROXY_TEST_DEPLOYMENT", "ACL_PROXY_TEST_REGION"]);
         env_guard.set("ACL_PROXY_TEST_DEPLOYMENT", "prod");
         env_guard.set("ACL_PROXY_TEST_REGION", "us-central1");
 
@@ -3808,7 +3962,7 @@ values = ["static", "${ACL_PROXY_TEST_DEPLOYMENT}", "${ACL_PROXY_TEST_REGION}", 
 
     #[test]
     fn header_action_env_interpolation_resolves_ruleset_template_placeholders() {
-        let env_guard = HeaderActionEnvTestGuard::new(&["ACL_PROXY_TEST_RULESET_TOKEN"]);
+        let env_guard = ConfigEnvTestGuard::new(&["ACL_PROXY_TEST_RULESET_TOKEN"]);
         env_guard.set("ACL_PROXY_TEST_RULESET_TOKEN", "token-123");
 
         let toml = r#"
@@ -3858,7 +4012,7 @@ include = "api_headers"
 
     #[test]
     fn header_action_env_interpolation_reports_missing_env_var() {
-        let env_guard = HeaderActionEnvTestGuard::new(&["ACL_PROXY_TEST_MISSING"]);
+        let env_guard = ConfigEnvTestGuard::new(&["ACL_PROXY_TEST_MISSING"]);
         env_guard.remove("ACL_PROXY_TEST_MISSING");
 
         let toml = r#"
@@ -3904,7 +4058,7 @@ value = "${ACL_PROXY_TEST_MISSING}"
 
     #[test]
     fn header_action_env_interpolation_resolves_egress_request_header_actions() {
-        let env_guard = HeaderActionEnvTestGuard::new(&["ACL_PROXY_TEST_EGRESS_TAG"]);
+        let env_guard = ConfigEnvTestGuard::new(&["ACL_PROXY_TEST_EGRESS_TAG"]);
         env_guard.set("ACL_PROXY_TEST_EGRESS_TAG", "edge-a");
 
         let toml = r#"
@@ -3942,7 +4096,7 @@ default = "deny"
 
     #[test]
     fn header_action_env_interpolation_reports_egress_action_location() {
-        let env_guard = HeaderActionEnvTestGuard::new(&["ACL_PROXY_TEST_MISSING_EGRESS"]);
+        let env_guard = ConfigEnvTestGuard::new(&["ACL_PROXY_TEST_MISSING_EGRESS"]);
         env_guard.remove("ACL_PROXY_TEST_MISSING_EGRESS");
 
         let toml = r#"
@@ -4122,7 +4276,7 @@ name = "authorization"
 
     #[test]
     fn header_action_env_interpolation_allows_empty_resolved_value() {
-        let env_guard = HeaderActionEnvTestGuard::new(&["ACL_PROXY_TEST_EMPTY"]);
+        let env_guard = ConfigEnvTestGuard::new(&["ACL_PROXY_TEST_EMPTY"]);
         env_guard.set("ACL_PROXY_TEST_EMPTY", "");
 
         let toml = r#"
@@ -4163,7 +4317,7 @@ value = "${ACL_PROXY_TEST_EMPTY}"
 
     #[test]
     fn load_from_sources_resolves_header_action_env_placeholders() {
-        let env_guard = HeaderActionEnvTestGuard::new(&["ACL_PROXY_TEST_LOAD_TOKEN"]);
+        let env_guard = ConfigEnvTestGuard::new(&["ACL_PROXY_TEST_LOAD_TOKEN"]);
         env_guard.set("ACL_PROXY_TEST_LOAD_TOKEN", "load-token");
 
         let mut file = tempfile::NamedTempFile::new().expect("create temp config");

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -71,6 +71,9 @@ fn default_external_auth_profile_type() -> ExternalAuthProfileType {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
+    #[serde(skip)]
+    pub load_warnings: Vec<String>,
+
     #[serde(default = "default_schema_version")]
     pub schema_version: String,
 
@@ -561,6 +564,7 @@ fn default_verify_upstream() -> bool {
 impl Default for Config {
     fn default() -> Self {
         Config {
+            load_warnings: Vec::new(),
             schema_version: default_schema_version(),
             proxy: ProxyConfig::default(),
             logging: LoggingConfig::default(),
@@ -1065,10 +1069,13 @@ impl Config {
     }
 
     fn interpolate_redaction_env_vars(&mut self) -> Result<(), ConfigError> {
+        let load_warnings = &mut self.load_warnings;
+
         for (profile_name, profile) in self.redaction.profiles.iter_mut() {
             interpolate_redaction_env_value(
                 &mut profile.replacement,
                 format!("redaction.profiles.{profile_name}.replacement").as_str(),
+                load_warnings,
             )?;
 
             for (rule_idx, rule) in profile.rules.iter_mut().enumerate() {
@@ -1079,6 +1086,7 @@ impl Config {
                             "redaction.profiles.{profile_name}.rules[{rule_idx}].literals[{literal_idx}]"
                         )
                         .as_str(),
+                        load_warnings,
                     )?;
                 }
             }
@@ -1233,13 +1241,12 @@ fn interpolate_header_action_value(
 fn interpolate_redaction_env_value(
     raw_value: &mut String,
     value_location: &str,
+    load_warnings: &mut Vec<String>,
 ) -> Result<(), ConfigError> {
     if has_incomplete_config_env_marker(raw_value) {
-        tracing::warn!(
-            target: "acl_proxy::config",
-            location = %value_location,
-            "redaction value contains '${{' but is not a complete placeholder; treating as literal text"
-        );
+        load_warnings.push(format!(
+            "{value_location} contains '${{' but is not a complete placeholder; treating as literal text"
+        ));
     }
 
     interpolate_config_env_value(raw_value, value_location, false)
@@ -1283,7 +1290,11 @@ fn has_incomplete_config_env_marker(raw_value: &str) -> bool {
 }
 
 fn classify_config_env_placeholder(raw_value: &str) -> ConfigEnvPlaceholder<'_> {
-    if has_incomplete_config_env_marker(raw_value) || !raw_value.contains("${") {
+    let Some(open_idx) = raw_value.find("${") else {
+        return ConfigEnvPlaceholder::None;
+    };
+
+    if !raw_value[open_idx + 2..].contains('}') {
         return ConfigEnvPlaceholder::None;
     }
 
@@ -2303,6 +2314,13 @@ redaction_profile = "secrets"
             .expect("load should preserve incomplete marker literal");
         let profile = config.redaction.profiles.get("secrets").expect("profile");
         assert_eq!(profile.rules[0].literals, vec!["pass${word".to_string()]);
+        assert_eq!(
+            config.load_warnings,
+            vec![
+                "redaction.profiles.secrets.rules[0].literals[0] contains '${' but is not a complete placeholder; treating as literal text"
+                    .to_string()
+            ]
+        );
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1262,7 +1262,12 @@ fn interpolate_config_env_value(
 }
 
 fn classify_config_env_placeholder(raw_value: &str) -> ConfigEnvPlaceholder<'_> {
-    if !raw_value.contains("${") {
+    let Some(open_idx) = raw_value.find("${") else {
+        return ConfigEnvPlaceholder::None;
+    };
+
+    let has_closing_brace = raw_value[open_idx + 2..].contains('}');
+    if !has_closing_brace {
         return ConfigEnvPlaceholder::None;
     }
 
@@ -3775,6 +3780,14 @@ external_auth_profile = "example"
             classify_config_env_placeholder("${_TOKEN_2}"),
             ConfigEnvPlaceholder::Exact { name: "_TOKEN_2" }
         );
+        assert_eq!(
+            classify_config_env_placeholder("pass${word"),
+            ConfigEnvPlaceholder::None
+        );
+        assert_eq!(
+            classify_config_env_placeholder("${TOKEN"),
+            ConfigEnvPlaceholder::None
+        );
 
         for raw in [
             "Bearer ${TOKEN}",
@@ -3782,7 +3795,6 @@ external_auth_profile = "example"
             "${}",
             "${1BAD}",
             "${BAD-NAME}",
-            "${TOKEN",
         ] {
             assert_eq!(
                 classify_config_env_placeholder(raw),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1069,6 +1069,7 @@ impl Config {
             interpolate_config_env_value(
                 &mut profile.replacement,
                 format!("redaction.profiles.{profile_name}.replacement").as_str(),
+                false,
             )?;
 
             for (rule_idx, rule) in profile.rules.iter_mut().enumerate() {
@@ -1079,6 +1080,7 @@ impl Config {
                             "redaction.profiles.{profile_name}.rules[{rule_idx}].literals[{literal_idx}]"
                         )
                         .as_str(),
+                        false,
                     )?;
                 }
             }
@@ -1227,18 +1229,27 @@ fn interpolate_header_action_value(
     raw_value: &mut String,
     action_location: &str,
 ) -> Result<(), ConfigError> {
-    interpolate_config_env_value(raw_value, action_location)
+    interpolate_config_env_value(raw_value, action_location, true)
 }
 
 fn interpolate_config_env_value(
     raw_value: &mut String,
     value_location: &str,
+    include_invalid_value: bool,
 ) -> Result<(), ConfigError> {
     match classify_config_env_placeholder(raw_value.as_str()) {
         ConfigEnvPlaceholder::None => Ok(()),
-        ConfigEnvPlaceholder::Invalid => Err(ConfigError::Invalid(format!(
-            "{value_location} uses invalid env interpolation syntax: '{raw_value}'"
-        ))),
+        ConfigEnvPlaceholder::Invalid => {
+            if include_invalid_value {
+                Err(ConfigError::Invalid(format!(
+                    "{value_location} uses invalid env interpolation syntax: '{raw_value}'"
+                )))
+            } else {
+                Err(ConfigError::Invalid(format!(
+                    "{value_location} uses invalid env interpolation syntax"
+                )))
+            }
+        }
         ConfigEnvPlaceholder::Exact { name } => {
             *raw_value = env::var(name).map_err(|_| {
                 ConfigError::Invalid(format!(
@@ -2165,7 +2176,7 @@ level = "debug"
 [redaction.profiles.secrets]
 
 [[redaction.profiles.secrets.rules]]
-literals = ["prefix-${ACL_PROXY_TEST_REDACTION_LITERAL}"]
+literals = ["secret-prefix-${ACL_PROXY_TEST_REDACTION_LITERAL}"]
 
 [policy]
 default = "deny"
@@ -2182,6 +2193,57 @@ default = "deny"
             ),
             "unexpected error message: {msg}"
         );
+        assert!(
+            !msg.contains("secret-prefix"),
+            "error message should not echo redaction literal: {msg}"
+        );
+    }
+
+    #[test]
+    fn load_from_sources_resolves_redaction_env_placeholders() {
+        let env_guard = ConfigEnvTestGuard::new(&[
+            "ACL_PROXY_TEST_LOAD_REDACTION_REPLACEMENT",
+            "ACL_PROXY_TEST_LOAD_REDACTION_LITERAL",
+        ]);
+        env_guard.set("ACL_PROXY_TEST_LOAD_REDACTION_REPLACEMENT", "[MASKED]");
+        env_guard.set("ACL_PROXY_TEST_LOAD_REDACTION_LITERAL", "load-secret");
+
+        let mut file = tempfile::NamedTempFile::new().expect("create temp config");
+        write!(
+            file,
+            r#"
+schema_version = "1"
+
+[proxy]
+bind_address = "127.0.0.1"
+http_port = 8080
+
+[logging]
+directory = "logs"
+level = "info"
+
+[redaction.profiles.secrets]
+replacement = "${{ACL_PROXY_TEST_LOAD_REDACTION_REPLACEMENT}}"
+
+[[redaction.profiles.secrets.rules]]
+literals = ["${{ACL_PROXY_TEST_LOAD_REDACTION_LITERAL}}"]
+
+[policy]
+default = "deny"
+
+[[policy.rules]]
+action = "allow"
+pattern = "https://example.com/**"
+redaction_profile = "secrets"
+            "#
+        )
+        .expect("write config");
+
+        let config = Config::load_from_sources(Some(file.path()))
+            .expect("load should resolve redaction placeholders");
+        let profile = config.redaction.profiles.get("secrets").expect("profile");
+        assert_eq!(profile.replacement, "[MASKED]");
+        assert_eq!(profile.rules[0].literals, vec!["load-secret".to_string()]);
     }
 
     #[test]

--- a/tests/config_cli.rs
+++ b/tests/config_cli.rs
@@ -2,6 +2,7 @@ use std::io::Write;
 use std::process::Command;
 
 use assert_cmd::prelude::*;
+use predicates::prelude::PredicateBooleanExt;
 use predicates::str::contains;
 use tempfile::{NamedTempFile, TempDir};
 
@@ -36,6 +37,55 @@ default = "deny"
     cmd.assert()
         .success()
         .stdout(contains("Configuration is valid"));
+}
+
+#[test]
+fn config_validate_warns_for_incomplete_redaction_env_marker() {
+    let mut file = NamedTempFile::new().expect("create temp config");
+    writeln!(
+        file,
+        r#"
+schema_version = "1"
+
+[proxy]
+bind_address = "127.0.0.1"
+http_port = 8080
+
+[logging]
+directory = "logs"
+level = "info"
+
+[redaction.profiles.secrets]
+
+[[redaction.profiles.secrets.rules]]
+literals = ["pass${{word"]
+
+[policy]
+default = "deny"
+
+[[policy.rules]]
+action = "allow"
+pattern = "https://example.com/**"
+redaction_profile = "secrets"
+        "#
+    )
+    .expect("write config");
+
+    let mut cmd = Command::new(assert_cmd::cargo_bin!("acl-proxy"));
+    cmd.arg("config")
+        .arg("validate")
+        .arg("--config")
+        .arg(file.path());
+
+    cmd.assert()
+        .success()
+        .stdout(contains("Configuration is valid"))
+        .stderr(
+            contains(
+                "warning: redaction.profiles.secrets.rules[0].literals[0] contains '${' but is not a complete placeholder",
+            )
+            .and(contains("pass${word").not()),
+        );
 }
 
 #[test]

--- a/tests/policy_cli.rs
+++ b/tests/policy_cli.rs
@@ -2,6 +2,7 @@ use std::io::Write;
 use std::process::Command;
 
 use assert_cmd::prelude::*;
+use predicates::prelude::PredicateBooleanExt;
 use predicates::str::contains;
 use serde_json::Value;
 use tempfile::NamedTempFile;
@@ -183,6 +184,54 @@ subnets = ["10.0.0.0/8"]
     let subnets = rule["subnets"].as_array().expect("subnets is an array");
     assert_eq!(subnets.len(), 1);
     assert_eq!(subnets[0], "10.0.0.0/8");
+}
+
+#[test]
+fn policy_dump_prints_config_load_warnings_to_stderr() {
+    let mut file = NamedTempFile::new().expect("create temp config");
+    file.write_all(
+        br#"
+schema_version = "1"
+
+[proxy]
+bind_address = "127.0.0.1"
+http_port = 8080
+
+[logging]
+directory = "logs"
+level = "info"
+
+[redaction.profiles.secrets]
+
+[[redaction.profiles.secrets.rules]]
+literals = ["pass${word"]
+
+[policy]
+default = "deny"
+
+[[policy.rules]]
+action = "allow"
+pattern = "https://example.com/api/**"
+        "#,
+    )
+    .expect("write config");
+
+    let mut cmd = Command::new(assert_cmd::cargo_bin!("acl-proxy"));
+    cmd.arg("policy")
+        .arg("dump")
+        .arg("--config")
+        .arg(file.path());
+
+    let assert = cmd.assert().success().stderr(
+        contains(
+            "warning: redaction.profiles.secrets.rules[0].literals[0] contains '${' but is not a complete placeholder",
+        )
+        .and(contains("pass${word").not()),
+    );
+    let stdout =
+        String::from_utf8(assert.get_output().stdout.clone()).expect("stdout is valid UTF-8");
+    let value: Value = serde_json::from_str(&stdout).expect("output is valid JSON");
+    assert_eq!(value["default"], "deny");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- resolve exact whole-string env placeholders in redaction profile replacement and literal entries
- reuse the existing config env placeholder contract used by header actions
- document the redaction env interpolation scope and keep regex expressions non-interpolated

## Testing
- cargo fmt --check
- cargo clippy
- cargo test
- cargo build --release
